### PR TITLE
Add FINOS CCC Maintainers to Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ The following are the FINOS CCC maintainers, the firms they represent and the ma
 
 | FINOS CCC Maintainer | Representing   | FINOS CCC Working Group                     |
 | -------------------- | -------------- | ------------------------------------------- |
-| Jonathan Meadows     | Citi           | OSCAL Representaion of CCC                  |
+| Jonathan Meadows     | Citi           | OSCAL Representation of CCC                 |
 | Jason Nelson         | Citi           | Engage with MITRE Threat Catalogue          |
 | Mark Rushing         | Citi           | Define Cloud Services Taxonomy              |
 | Moe Matar            | Citi           | Define Cloud Services Taxonomy              | 
@@ -50,10 +50,10 @@ The following are the FINOS CCC maintainers, the firms they represent and the ma
 | Adrian Hammond       | Red Hat        | Define Cloud Services Taxonomy              |
 | Naseer Mohammad      | Google         | Engage with MITRE Threat Catalogue          |
 | Valentin Mihai       | Google         | TBC                                         |
-| Rachel Kim           | Google         | OSCAL Representaion of CCC                  | 
+| Rachel Kim           | Google         | OSCAL Representation of CCC                 | 
 | Raj Krishnamurthy    | Compliance Cow | Engage with MITRE Threat Catalogue          | 
 | Vicente Herrera      | Control Plane  | Define Cloud Services Taxonomy              |
-| Michaela Iorga       | NIST           | OSCAL Representaion of CCC                  | 
+| Michaela Iorga       | NIST           | OSCAL Representation of CCC                 | 
 
 ## License
 


### PR DESCRIPTION
## Description
This PR adds the newly elected FINOS CCC maintainers at #53 to the project `Readme.md` and includes the maintainer's working group alignment where known.

### Markdown Addition

```
## CCC Project Maintainers

FINOS Common Cloud Controls is maintained by FINOS members and the wider open source in finance community. 

The following are the FINOS CCC maintainers, the firms they represent and the maintainer working group alignment.   

| FINOS CCC Maintainer | Representing   | FINOS CCC Working Group                     |
| -------------------- | -------------- | ------------------------------------------- |
| Jonathan Meadows     | Citi           | OSCAL Representation of CCC                 |
| Jason Nelson         | Citi           | Engage with MITRE Threat Catalogue          |
| Mark Rushing         | Citi           | Define Cloud Services Taxonomy              |
| Moe Matar            | Citi           | Define Cloud Services Taxonomy              | 
| Anna Selyugina       | Goldman Sachs  | Engage with MITRE & Cloud Services Taxonomy |
| Paul Stevenson       | Morgan Stanley | TBC                                         |
| Simon Zhang          | BMO            | Define Cloud Services Taxonomy              |  
| Adrian Hammond       | Red Hat        | Define Cloud Services Taxonomy              |
| Naseer Mohammad      | Google         | Engage with MITRE Threat Catalogue          |
| Valentin Mihai       | Google         | TBC                                         |
| Rachel Kim           | Google         | OSCAL Representation of CCC                 | 
| Raj Krishnamurthy    | Compliance Cow | Engage with MITRE Threat Catalogue          | 
| Vicente Herrera      | Control Plane  | Define Cloud Services Taxonomy              |
| Michaela Iorga       | NIST           | OSCAL Representation of CCC                 |  
```
