### PR TITLE
Fix broken logo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
 [![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Incubating)
 
-<img height="100px" src="https://github.com/finos/branding/blob/master/project-logos/active-project-logos/FINOS%20Common%20Cloud%20Controls%20Logo/Horizontal/2023_FinosCCC_Horizontal.svg?raw=true"/>
+<img height="100px" src="https://github.com/finos/branding/blob/master/project-logos/active-project-logos/Common%20Cloud%20Controls/Horizontal/2023_FinosCCC_Horizontal.svg?raw=true"/>
 
-FINOS Common Cloud Controls (FINOS CCC) is the codename for an open standard project, originally proposed by Citi and currently incubating in FINOS, to describe consistent controls for compliant public cloud deployments in the financial services sector.
+FINOS Common Cloud Controls (FINOS CCC) is an open standard project, originally proposed by Citi and currently incubating in FINOS, to describe consistent controls for compliant public cloud deployments in the financial services sector.
 
 This standard is a collaborative project which aims to develop a unified set of cybersecurity, resiliency, and compliance controls for common services across the major cloud service providers (CSPs).
 


### PR DESCRIPTION
I also removed the erroneous "codename" phrase from right beside the logo.

ref: https://github.com/finos/branding/issues/32