### PR TITLE
Fix link to delivery wg in taxonomy charter

### DIFF
--- a/docs/governance/working-groups/taxonomy/charter.md
+++ b/docs/governance/working-groups/taxonomy/charter.md
@@ -75,3 +75,4 @@ Any functional changes to this charter must be approved through a majority vote 
 [recommendations]: <../../community-recommendations/README.md>
 [Communications WG]: <../communications/charter.md>
 [Community Structure WG]: <../communications/charter.md>
+[Delivery WG]: <../delivery/charter.md>


### PR DESCRIPTION
Fix the link to the delivery working group in the taxonomy working groups charter.