### PR TITLE
New workflow to close issues tagged with "meeting" after 14 days.

### DIFF
--- a/.github/workflows/stale_meeting.yml
+++ b/.github/workflows/stale_meeting.yml
@@ -1,0 +1,24 @@
+name: Auto Close Stale Meeting Issues
+
+on:
+    schedule:
+    - cron: '18 22 * * *'
+
+jobs:
+  close_stale_meeting:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 13
+          days-before-issue-close: 1 # Marked as stale the day before closing
+          stale-issue-label: "stale_meeting"
+          stale-issue-message: "This issue is stale because it has been open for 13 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          only-labels: "meeting"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Addresses issue https://github.com/finos/common-cloud-controls/issues/231

Add a new workflow rule which will close issues labeled "meeting" after 14 days of inactivity.