### PR TITLE
Upgrade member roles to policy

### DIFF
--- a/docs/governance/community-policies/member-roles.md
+++ b/docs/governance/community-policies/member-roles.md
@@ -6,7 +6,7 @@ The following are roles and additional responsibilities that a person may reciev
 
 | Role     | Responsibilities                                                                        | Requirements                                                                     | Defined by                                                           |
 | -------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Member   | Active contributor in the community, assist on community calls, give input on proposals | Sponsored by 2 reviewers after multiple contributions to the project             | GitHub FINOS `ccc-members` Group Member                              |
+| Member   | Active contributor in the community, assist on community calls, give input on proposals | Sponsored by 2 approvers after multiple contributions to the project             | GitHub FINOS `ccc-members` Group Member                              |
 | Approver | Review contributions from other members                                                 | History of quality reviews and authorship in a particular space                  | [CODEOWNERS] entry for specific files or directories                 |
 | WG Lead  | Set direction and priorities for a working group (WG)                                   | Demonstrated responsibility and excellent technical judgement for the subproject | [CODEOWNERS] entry for all files or directories relating to the [WG] |
 

--- a/docs/governance/community-policies/member-roles.md
+++ b/docs/governance/community-policies/member-roles.md
@@ -7,8 +7,8 @@ The following are roles and additional responsibilities that a person may reciev
 | Role     | Responsibilities                                                                        | Requirements                                                                     | Defined by                                                           |
 | -------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | Member   | Active contributor in the community, assist on community calls, give input on proposals | Sponsored by 2 approvers after multiple contributions to the project             | GitHub FINOS `ccc-members` Group Member                              |
-| Approver | Review contributions from other members                                                 | History of quality reviews and authorship in a particular space                  | [CODEOWNERS] entry for specific files or directories                 |
-| WG Lead  | Set direction and priorities for a working group (WG)                                   | Demonstrated responsibility and excellent technical judgement for the subproject | [CODEOWNERS] entry for all files or directories relating to the [WG] |
+| Approver | Review contributions from other members                                                 | History of quality reviews and authorship in a particular space                  | Member of the corresponding approvers GitHub team                 |
+| WG Lead  | Set direction and priorities for a working group (WG)                                   | Demonstrated responsibility and excellent technical judgement for the subproject | Maintainer of the corresponding approvers GitHub team |
 
 ## All New & Established Contributors
 


### PR DESCRIPTION
Proposal from community structure working group to upgrade the guidelines outlining the member roles a policy.

https://github.com/finos/common-cloud-controls/blob/main/docs/governance/community-guidelines/member-roles.md