### PR TITLE
Add yaml schemas (Issue #364)

### DIFF
--- a/docs/governance/community-guidelines/templates/schemas/README.md
+++ b/docs/governance/community-guidelines/templates/schemas/README.md
@@ -1,0 +1,16 @@
+# Yaml Validation Schemas
+Yaml validation schemas have been created for controls, features, metadata and threats files. 
+
+## VSCode integration
+You can update VSCode to highlight issues using the schema files with the following steps:
+1. Install VSCode [Red Hat YAML extension](https://github.com/redhat-developer/vscode-yaml)
+2. Under VSCode `settings.json` add the following:
+```json
+    "yaml.schemas": {
+        "file:///<PATH_TO_CCC_REPO>/common-cloud-controls/docs/governance/community-guidelines/templates/schemas/controls-schema.json": "controls.yaml",
+        "file:///<PATH_TO_CCC_REPO>/common-cloud-controls/docs/governance/community-guidelines/templates/schemas/features-schema.json": "features.yaml",
+        "file:///<PATH_TO_CCC_REPO>/common-cloud-controls/docs/governance/community-guidelines/templates/schemas/metadata-schema.json": "metadata.yaml",
+        "file:///<PATH_TO_CCC_REPO>/common-cloud-controls/docs/governance/community-guidelines/templates/schemas/threats-schema.json": "threats.yaml"
+    }
+```
+3. Save these settings and reload VSCode.

--- a/docs/governance/community-guidelines/templates/schemas/controls-schema.json
+++ b/docs/governance/community-guidelines/templates/schemas/controls-schema.json
@@ -1,0 +1,91 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "common_controls": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "IDs of common controls; can be omitted if not applicable"
+        }
+      },
+      "controls": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Control ID in the format CCC.<Service Category Abbreviation>.C1"
+            },
+            "title": {
+              "type": "string",
+              "description": "Name of the control"
+            },
+            "objective": {
+              "type": "string",
+              "description": "1-3 sentence description of the control objective"
+            },
+            "control_family": {
+              "type": "string",
+              "description": "Control Family"
+            },
+            "nist_csf": {
+              "type": "string",
+              "description": "NIST CSF control ID"
+            },
+            "mitre_attack": {
+              "type": "string",
+              "description": "Mitre ATT&CK technique ID"
+            },
+            "threats": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Threat IDs"
+              }
+            },
+            "control_mappings": {
+              "type": "object",
+              "properties": {
+                "CCM": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "description": "CCM control IDs"
+                  }
+                },
+                "ISO_27001": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "description": "ISO 27001 control IDs"
+                  }
+                },
+                "NIST_800_53": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "description": "NIST 800-53 control IDs"
+                  }
+                }
+              },
+              "required": ["CCM", "ISO_27001", "NIST_800_53"],
+              "additionalProperties": false
+            },
+            "test_requirements": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string",
+                "description": "Test requirement descriptions"
+              }
+            }
+          },
+          "required": ["id", "title", "objective", "control_family", "nist_csf", "mitre_attack", "threats", "control_mappings", "test_requirements"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": ["controls"],
+    "additionalProperties": false
+  }

--- a/docs/governance/community-guidelines/templates/schemas/features-schema.json
+++ b/docs/governance/community-guidelines/templates/schemas/features-schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "common_features": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "IDs of common features; can be omitted if not applicable"
+        }
+      },
+      "features": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Feature ID in the format CCC.<Service Category Abbreviation>.F<##>"
+            },
+            "title": {
+              "type": "string",
+              "description": "Shortname of the feature"
+            },
+            "description": {
+              "type": "string",
+              "description": "Complete description of the feature"
+            }
+          },
+          "required": ["id", "title", "description"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": ["features"],
+    "additionalProperties": false
+  }

--- a/docs/governance/community-guidelines/templates/schemas/metadata-schema.json
+++ b/docs/governance/community-guidelines/templates/schemas/metadata-schema.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "description": "Service Category Name"
+      },
+      "id": {
+        "type": "string",
+        "pattern": "^CCC\\.[A-Za-z]+$",
+        "description": "Control ID in the format CCC.<Service Category Abbreviation>"
+      },
+      "description": {
+        "type": "string",
+        "description": "Complete description of the Service Category"
+      },
+      "assurance_level": {
+        "type": "string",
+        "description": "Assurance Level Abbreviation"
+      },
+      "threat_model_author": {
+        "type": "string",
+        "description": "Name of the organization or lead author for the threat model"
+      },
+      "threat_model_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL to the threat model document"
+      },
+      "red_team": {
+        "type": "string",
+        "description": "Name of the organization or team lead for the red team exercise"
+      },
+      "red_team_exercise_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL to the red team exercise report"
+      }
+    },
+    "required": ["title", "id", "description", "assurance_level", "threat_model_author", "threat_model_url", "red_team", "red_team_exercise_url"],
+    "additionalProperties": false
+  }

--- a/docs/governance/community-guidelines/templates/schemas/threats-schema.json
+++ b/docs/governance/community-guidelines/templates/schemas/threats-schema.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "common_threats": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "description": "IDs of common threats; can be omitted if not applicable"
+        }
+      },
+      "threats": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9]+\\.TH\\d{2}$",
+              "description": "Threat ID in the format <category-id>.TH##"
+            },
+            "title": {
+              "type": "string",
+              "description": "Short name of the threat"
+            },
+            "description": {
+              "type": "string",
+              "description": "Complete description of the threat"
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9]+\\.F\\d+$",
+                "description": "Feature ID in the format <category-id>.F<#>"
+              }
+            },
+            "mitre_attack": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Mitre ATT&CK tactic or technique ID"
+              },
+              "minItems": 1
+            }
+          },
+          "required": ["id", "title", "description", "features", "mitre_attack"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": ["threats"],
+    "additionalProperties": false
+  }


### PR DESCRIPTION
Add YAML schemas for controls, features, metadata and threats. Tested locally with VSCode

Using draft-07 as it seems most widely supported

![image](https://github.com/user-attachments/assets/29e11ee5-1f79-40e7-bfc7-b0a9d21ade65)
