### PR TITLE
Increase the vote duration to 7 days and remove the status check

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,15 +1,15 @@
 profiles:
   default:
-    # Voting duration of 5 days
-    duration: 5d
+    # Voting duration of 7 days
+    duration: 7d
     # Pass threshold of 51% (i.e. majority)
     pass_threshold: 51
     allowed_voters:
       teams: [ccc-steerco]
       users: []
 
-    # Periodic status check - automatically check the vote after 1 day
-    periodic_status_check: 1d
+    # Periodic status check - no status check
+    periodic_status_check: null
 
     # Close vote on passing
     close_on_passing: true


### PR DESCRIPTION
Increase the vote duration form 5 days to 7 days to ensure we give a full working week to vote (ignoring any holidays).

Remove the daily status check as it was causing confusion and noise on the PRs.