### PR TITLE
Adding TODO Checker

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -21,9 +21,15 @@ jobs:
         permissions:
           pull-requests: write
           contents: read
-
   yaml-checker:
     uses: ./.github/workflows/yaml-check.yml
     permissions:
       pull-requests: write
       contents: read
+
+  todo-checker:
+    uses: ./.github/workflows/todo-check.yml
+    permissions:
+      pull-requests: write
+      contents: read
+      

--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for TODOs in services directory         
-        uses: damienjburks/simple-todo-checker@0.1.3-alpha
+        uses: damienjburks/simple-todo-checker@1.0.0
         with: 
           path: "./services"
     

--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -15,4 +15,7 @@ jobs:
         uses: phntmxyz/pr_todo_checker@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          comment_on_todo: false
+          comment_on_todo: true
+          comment_body: |
+            "Please resolve the TODO item above."
+          comment_checkbox: 'Acknowledged'

--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -4,7 +4,7 @@ on:
     workflow_call:
 
 jobs:
-  find_todos:
+  find-todos:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -11,11 +11,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Check for Todos
-        uses: phntmxyz/pr_todo_checker@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          comment_on_todo: true
-          comment_body: |
-            "Please resolve the TODO item above."
-          comment_checkbox: 'Acknowledged'
+      - name: Check for TODOs in services directory         
+        uses: damienjburks/simple-todo-checker@0.1.3-alpha
+        with: 
+          path: "./services"
+    

--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -1,0 +1,17 @@
+name: TODO Checker
+
+on:
+    workflow_call:
+
+jobs:
+  find_todos:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for Todos
+        uses: phntmxyz/pr_todo_checker@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/todo-check.yml
+++ b/.github/workflows/todo-check.yml
@@ -15,3 +15,4 @@ jobs:
         uses: phntmxyz/pr_todo_checker@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          comment_on_todo: false

--- a/docs/governance/community-guidelines/releases/cmb.md
+++ b/docs/governance/community-guidelines/releases/cmb.md
@@ -11,7 +11,7 @@ The CMB is a body of representatives from financial institutions of varying size
 ## Process
 
 The process followed by the CMB to manage changes includes:
-	
+
 1. **Proposal Submission**
    - Proposed changes are submitted for CMB review by contributors or working groups within the CCC project.
 1. **Review Cycle**
@@ -20,7 +20,7 @@ The process followed by the CMB to manage changes includes:
    - After review, the CMB either approves the proposed changes for the next release candidate or requests modifications and additional feedback from the contributor or associated working group.
 1. **Final Approval and Release**
    - Upon receiving approval, the release manager compiles the final release package, and the CMB confirms the official release of the updated framework.
-   
+
 ## Membership
 
 The change management board is composed of a Release Manager and the body of reviewers, both appointed by the [Delivery WG].

--- a/services/common-controls.yaml
+++ b/services/common-controls.yaml
@@ -6,6 +6,7 @@ control_families:
   - Software Supply Chain
   - Network Security
 
+# TODO: Whaaat
 controls:
   - id: CCC.C01 # Prevent unencrypted requests
     title: Prevent unencrypted requests

--- a/services/common-controls.yaml
+++ b/services/common-controls.yaml
@@ -6,7 +6,6 @@ control_families:
   - Software Supply Chain
   - Network Security
 
-# TODO: Whaaat
 controls:
   - id: CCC.C01 # Prevent unencrypted requests
     title: Prevent unencrypted requests


### PR DESCRIPTION
This PR contains the addition of a new action that'll scan the YAMLs for TODO's in the comments, fail the pipeline, and pointing them out. I also fixed the linting issues for the CMB.md file.  