### PR TITLE
Update sonatype_scan.yaml

### DIFF
--- a/.github/workflows/sonatype_scan.yaml
+++ b/.github/workflows/sonatype_scan.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    # if: github.repository_owner == 'finos'
+    if: github.repository_owner == 'finos'
     name: Build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Uncomment line that was accidentally commented out. This will make it so it only runs the job if the repository owner is `finos`.