### PR TITLE
#534: Add yaml linter

### DIFF
--- a/.config/.markdownlint.yaml
+++ b/.config/.markdownlint.yaml
@@ -84,7 +84,7 @@ MD022:
 MD023: true
 
 # MD024/no-duplicate-heading : Multiple headings with the same content : https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md024.md
-MD024: 
+MD024:
   siblings_only: true
 
 # MD025/single-title/single-h1 : Multiple top-level headings in the same document : https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md025.md

--- a/.config/.yamllint
+++ b/.config/.yamllint
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  indentation:
+    spaces: 2 # Enforce 2 spaces for indentation
+  line-length:
+    max: 120 # Allow up to 120 characters per line

--- a/.github/workflows/linting-check.yml
+++ b/.github/workflows/linting-check.yml
@@ -21,3 +21,24 @@ jobs:
 
       - name: Run markdownlint
         run: markdownlint '**/*.md' --config ./.config/.markdownlint.yaml
+
+  yaml-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x" # Use any compatible Python 3 version
+
+      - name: Install yamllint
+        run: |
+          python -m pip install --upgrade pip
+          pip install yamllint
+
+      - name: Run yamllint
+        run: |
+          yamllint -c ./.config/.yamllint .


### PR DESCRIPTION
Add [yamllint](https://yamllint.readthedocs.io/en/stable/configuration.html#default-configuration) as a workflow job to ensure the yaml files are consistent with the markdown.

Addresses issue #534 

There are quite a few fails for the linter so I'll address those in a different PR
