### PR TITLE
Change GitHub Actions trigger from pull_request to pull_request_target

### DIFF
--- a/.github/workflows/sonatype_scan.yaml
+++ b/.github/workflows/sonatype_scan.yaml
@@ -2,7 +2,7 @@
 name: Sonatype SCA Scanning
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     paths: 
       - "**.go"
       - "**/go.mod"


### PR DESCRIPTION
Updated the workflow trigger event to use 'pull_request_target' instead of 'pull_request'. This allows workflows to run with access to secrets and environment variables in the context of the base (target) branch.