### PR TITLE
change(control): add in missing controls mappings for object storage

### DIFF
--- a/services/storage/object/controls.yaml
+++ b/services/storage/object/controls.yaml
@@ -120,9 +120,13 @@ controls:
     threats:
       - CCC.TH06 # Data is Lost or Corrupted
     control_mappings:
-      CCM: []
-      ISO_27001: []
-      NIST_800_53: []
+      CCM:
+        - DSP-16 # Data Retention and Deletion
+      ISO_27001:
+        - 2022 A.8.1.4 # Handling of Assets
+      NIST_800_53:
+        - SC-28 # Protection of Information at Rest
+        - CP-10 # System Recovery and Reconstitution
     test_requirements:
       - id: CCC.ObjStor.C03.TR01
         text: |
@@ -155,9 +159,13 @@ controls:
     threats:
       - CCC.TH06 # Data is Lost or Corrupted
     control_mappings:
-      CCM: []
-      ISO_27001: []
-      NIST_800_53: []
+      CCM:
+        - DSP-16 # Data Retention and Deletion
+      ISO_27001:
+        - 2022 A.8.1.4 # Handling of Assets
+      NIST_800_53:
+        - SC-28 # Protection of Information at Rest
+        - CP-10 # System Recovery and Reconstitution
     test_requirements:
       - id: CCC.ObjStor.C04.TR01
         text: |
@@ -191,9 +199,13 @@ controls:
     threats:
       - CCC.TH06 # Data is Lost or Corrupted
     control_mappings:
-      CCM: []
-      ISO_27001: []
-      NIST_800_53: []
+      CCM:
+        - DSP-16 # Data Retention and Deletion
+      ISO_27001:
+        - 2022 A.8.1.4 # Handling of Assets
+      NIST_800_53:
+        - SC-28 # Protection of Information at Rest
+        - CP-10 # System Recovery and Reconstitution
     test_requirements:
       - id: CCC.ObjStor.C05.TR01
         text: |
@@ -246,9 +258,14 @@ controls:
       - CCC.TH07 # Logs are Tampered With or Deleted
       - CCC.TH09 # Logs or Monitoring Data are Read by Unauthorized Users
     control_mappings:
-      CCM: []
-      ISO_27001: []
-      NIST_800_53: []
+      CCM:
+        - DSP-07 # Data Protection by Design and Default
+        - DSP-17 # Sensitive Data Protection
+      ISO_27001:
+        - 2022 A.8.15.0 # Logging
+      NIST_800_53:
+        - AU-9 # Protection of Audit Information
+        - SC-28 # Protection of Information at Rest
     test_requirements:
       - id: CCC.ObjStor.C06.TR01
         text: |


### PR DESCRIPTION
This pull request includes updates to the `controls.yaml` file in the `services/storage/object` directory.

Key changes include:

* Updated `control_mappings` for threats CCC.TH06, CCC.TH07 and CCC.TH09:
  * Added mappings for `CCM`, `ISO_27001`, and `NIST_800_53` standards.