### PR TITLE
change(ci): simplify codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,80 +1,20 @@
-########
-#
-# In the event that a file is not covered by policies below, the 
-# Community Structure WG should advise changes or create a new 
-# CODEOWNERS entry for it.
-#
-# NOTE: If the GitHub automated reviewers do not behave as expected,
-#       please contact the Community Structure WG.
-/* @finos/ccc-wg-community-structure
-#
-########
+**/charter.md @finos/ccc-steerco
+/.github @finos/ccc-steerco
+/docs/governance @finos/ccc-steerco
 
-########
-#
-# Changes that might impact automation must be reviewed by the Delivery WG
-# Code owners should only be modified by the SteerCo
-/.github @finos/ccc-wg-delivery
-/.github/CODEOWNERS @finos/ccc-steerco
-/.vscode @finos/ccc-wg-delivery
-/delivery-toolkit @finos/ccc-wg-delivery
-#
-########
-
-########
-#
-# Community Guidelines only need review from the Community Structure WG
+/docs/governance/working-groups/community-structure @finos/ccc-wg-community-structure @finos/ccc-steerco
+/.vscode @finos/ccc-wg-community-structure
 /docs/community-guidelines @finos/ccc-wg-community-structure
-#
-########
+/* @finos/ccc-wg-community-structure
 
-########
-#
-# Each WG may place ad hoc documentation in their governance subdirectory
-/docs/governance/working-groups/communications @finos/ccc-wg-communications
-/docs/governance/working-groups/community-structure @finos/ccc-wg-community-structure
-/docs/governance/working-groups/delivery @finos/ccc-wg-delivery
-/docs/governance/working-groups/duplication-reduction @finos/ccc-wg-community-structure
-/docs/governance/working-groups/security @finos/ccc-wg-security
-/docs/governance/working-groups/taxonomy @finos/ccc-wg-taxonomy
-#
-########
-
-########
-#
-# Changes to the services directory must be reviewed by the Taxonomy WG
-# excluding threats and controls definitions
-/services @finos/ccc-wg-taxonomy
+/docs/governance/working-groups/taxonomy @finos/ccc-wg-taxonomy @finos/ccc-steerco
 **/capabilities.yaml @finos/ccc-wg-taxonomy
-#
-########
+**/service-categories.yaml
+services/service-families.yaml
 
-########
-#
-# Threats or controls definition changes must be reviewed by the Security WG
+/docs/governance/working-groups/security @finos/ccc-wg-security @finos/ccc-steerco
 **/threats.yaml @finos/ccc-wg-security
 **/controls.yaml @finos/ccc-wg-security
 **/*.feature @finos/ccc-wg-security
-#
-########
 
-#
-# Additional Changes that might impact automation must be reviewed by the 
-# Delivery WG
-**/metadata.yaml @finos/ccc-wg-delivery
-#
-########
-
-########
-
-########
-
-########
-#
-# Charters and policies require review from at least one SteerCo member
-# Policies also require review from the Community Structure WG
-/docs/governance/steering @finos/ccc-steerco
-/docs/governance @finos/ccc-steerco @finos/ccc-wg-community-structure
-**/charter.md @finos/ccc-steerco
-#
-########
+/docs/governance/working-groups/communications @finos/ccc-wg-communications @finos/ccc-steerco


### PR DESCRIPTION
The comments in this file have increased maintenance overhead, so this change removes them.

It also removes the Delivery WG from codeowners ahead of the official decommissioning of that group, and makes some other changes to required reviewers.

I recommend looking at the final changed file instead of the diff, which is a bit cumbersome.