### PR TITLE
add: use gemara@v.0.3.9 in place of sci

### DIFF
--- a/delivery-toolkit/cmd/catalog-compiler.go
+++ b/delivery-toolkit/cmd/catalog-compiler.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/revanite-io/sci/layer2"
+	"github.com/ossf/gemara/layer2"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )

--- a/delivery-toolkit/cmd/types.go
+++ b/delivery-toolkit/cmd/types.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "github.com/revanite-io/sci/layer2"
+import "github.com/ossf/gemara/layer2"
 
 type CompiledCatalog struct {
 	Metadata             layer2.Metadata  `yaml:"metadata"`

--- a/delivery-toolkit/cmd/update-metadata.go
+++ b/delivery-toolkit/cmd/update-metadata.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v53/github"
-	"github.com/revanite-io/sci/layer2"
+	"github.com/ossf/gemara/layer2"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"

--- a/delivery-toolkit/go.mod
+++ b/delivery-toolkit/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/google/go-github/v53 v53.2.0
-	github.com/revanite-io/sci v0.3.8
+	github.com/ossf/gemara v0.3.9
 	golang.org/x/oauth2 v0.24.0
 	gopkg.in/yaml.v3 v3.0.1
 )


### PR DESCRIPTION
go module revanite-io/sci@v0.3.8 will become
ossf/gemara@v0.3.9 soon, this PR lays the groundwork to adopt that change