### PR TITLE
Add: Audit Logs Threats

### DIFF
--- a/services/management/auditlog/threats.yaml
+++ b/services/management/auditlog/threats.yaml
@@ -1,0 +1,10 @@
+shared-threats:
+  - reference-id: CCC
+    identifiers:
+      - CCC.TH01 # Access Control is Misconfigured
+      - CCC.TH04 # Data is Replicated to Untrusted or External Locations
+      - CCC.TH06 # Data is Lost or Corrupted
+      - CCC.TH07 # Logs are Tampered With or Deleted
+      - CCC.TH09 # Logs or Monitoring Data are Read by Unauthorized Users
+      - CCC.TH10 # Alerts are Intercepted
+      - CCC.TH16 # Logging and Monitoring are Disabled


### PR DESCRIPTION
I've added a collection of shared threats for the control. Adding specific threats I've found quite difficult because everything I could think off was already covered by the shared threats. I've put some of my ideas below, please feel free to raise anything I've not through of:

Delete CloudTrail Trail - prevents logs being sent to s3 buckets
Disrupt CloudTrail Logging by creating an event selector on the Trail, filtering out all management events.
Set a 1-day retention policy on the S3 bucket used by a CloudTrail Trail, using a S3 Lifecycle Rule.
Lifecycle-Triggered Deletion (T1485.001) / (T1485.001, T1578.003)
https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html#stealth-iam-cloudtrailloggingdisabled
google.logging.v2.ConfigServiceV2.UpdateSink (falls into CCC.TH01/CCC.TH07)
Defense Evasion (TA0005) / T1562.008: Disable or Modify Cloud Logs