### PR TITLE
change(threat): Changed threats to show title when minimized in the IDE

### DIFF
--- a/catalogs/core/ccc/threats.yaml
+++ b/catalogs/core/ccc/threats.yaml
@@ -24,8 +24,8 @@
 #   - The reference-id for mappings should be an ID defined in metadata.mapping-references[]
 
 threats:
-  - id: CCC.Core.TH01
-    title: Access Control is Misconfigured
+  - title: Access Control is Misconfigured
+    id: CCC.Core.TH01
     description: |
       Misconfigured access controls may grant excessive privileges or fail to
       restrict unauthorized access to the service and its child resources.
@@ -77,8 +77,8 @@ threats:
           - reference-id: T1027
             strength: 0 # Not yet specified
             remarks: Obfuscated Files or Information
-  - id: CCC.Core.TH02
-    title: Data is Intercepted in Transit
+  - title: Data is Intercepted in Transit
+    id: CCC.Core.TH02
     description: |
       Data transmitted by the service is susceptible to collection by any entity
       with access to any part of the transmission path. Packet observations can
@@ -98,8 +98,8 @@ threats:
           - reference-id: T1040
             strength: 0 # Not yet specified
             remarks: Network Sniffing
-  - id: CCC.Core.TH03
-    title: Deployment Region Network is Untrusted
+  - title: Deployment Region Network is Untrusted
+    id: CCC.Core.TH03
     description: |
       Systems are susceptible to unauthorized access or interception by actors
       with social or physical control over the network in which they are
@@ -133,8 +133,8 @@ threats:
           - reference-id: T1557
             strength: 0 # Not yet specified
             remarks: Adversary-in-the-Middle
-  - id: CCC.Core.TH04
-    title: Data is Replicated to Untrusted or External Locations
+  - title: Data is Replicated to Untrusted or External Locations
+    id: CCC.Core.TH04
     description: |
       Systems are susceptible to unauthorized access or interception by actors
       with political or physical control over the network in which they are
@@ -152,8 +152,8 @@ threats:
           - reference-id: T1565
             strength: 0 # Not yet specified
             remarks: Data Manipulation
-  - id: CCC.Core.TH05
-    title: Interference with Replication Processes
+  - title: Interference with Replication Processes
+    id: CCC.Core.TH05
     description: |
       Misconfigured or manipulated replication processes may lead to data being
       copied to unintended locations, delayed, modified, or not being copied
@@ -186,8 +186,8 @@ threats:
           - reference-id: T1490
             strength: 0 # Not yet specified
             remarks: Inhibit System Recovery
-  - id: CCC.Core.TH06
-    title: Data is Lost or Corrupted
+  - title: Data is Lost or Corrupted
+    id: CCC.Core.TH06
     description: |
       Services that rely on accurate data are susceptible to disruption in the
       event of data loss or corruption. Any actions that lead to the unintended
@@ -217,8 +217,8 @@ threats:
           - reference-id: T1490
             strength: 0 # Not yet specified
             remarks: Inhibit System Recovery
-  - id: CCC.Core.TH07
-    title: Logs are Tampered With or Deleted
+  - title: Logs are Tampered With or Deleted
+    id: CCC.Core.TH07
     description: |
       Tampering or deletion of service logs will reduce the system's ability to
       maintain an accurate record of events. Any actions that compromise the
@@ -246,8 +246,8 @@ threats:
           - reference-id: T1027
             strength: 0 # Not yet specified
             remarks: Obfuscated Files or Information
-  - id: CCC.Core.TH08
-    title: Runtime Metrics are Manipulated
+  - title: Runtime Metrics are Manipulated
+    id: CCC.Core.TH08
     description: |
       Manipulation of runtime metrics can lead to inaccurate representations of
       system performance and resource utilization. This compromised data
@@ -268,8 +268,8 @@ threats:
             remarks: Data Manipulation
           - reference-id: T1070
             remarks: Indicator Removal on Host
-  - id: CCC.Core.TH09
-    title: Runtime Logs are Read by Unauthorized Entities
+  - title: Runtime Logs are Read by Unauthorized Entities
+    id: CCC.Core.TH09
     description: |
       Unauthorized access to logs may expose valuable information about the
       system's configuration, operations, and security mechanisms. This could
@@ -328,14 +328,14 @@ threats:
           - reference-id: T1518
             strength: 0 # Not yet specified
             remarks: Software Discovery
-  - id: CCC.Core.TH19
-    title: Metrics are Read by Unauthorized Entities
+  - title: Metrics are Read by Unauthorized Entities
+    id: CCC.Core.TH19
     description: |
       Unauthorized access to runtime metrics may expose valuable information
       about the system's design, performance, and usage patterns. This can
       support the planning of attacks on the service, system, or network.
-  - id: CCC.Core.TH10
-    title: State-change Events are Read by Unauthorized Entities
+  - title: State-change Events are Read by Unauthorized Entities
+    id: CCC.Core.TH10
     description: |
       Unauthorized access to state-change events can reveal information about
       the system's design and usage patterns. This opens the system up to
@@ -368,8 +368,8 @@ threats:
           - reference-id: T1083
             strength: 0 # Not yet specified
             remarks: File and Directory Discovery
-  - id: CCC.Core.TH11
-    title: Publications are Incorrectly Triggered
+  - title: Publications are Incorrectly Triggered
+    id: CCC.Core.TH11
     description: |
       Incorrectly triggered publications may disseminate inaccurate
       or misleading information, creating a data integrity risk. Such
@@ -397,8 +397,8 @@ threats:
           - reference-id: T1491.001
             strength: 0 # Not yet specified
             remarks: "Defacement: Internal Defacement"
-  - id: CCC.Core.TH12
-    title: Resource Constraints are Exhausted
+  - title: Resource Constraints are Exhausted
+    id: CCC.Core.TH12
     description: |
       Exceeding the resource constraints through excessive consumption,
       resource-intensive operations, or lowering of rate-limit thresholds
@@ -431,8 +431,8 @@ threats:
           - reference-id: T1498
             strength: 0 # Not yet specified
             remarks: Network Denial of Service
-  - id: CCC.Core.TH13
-    title: Resource Tags are Manipulated
+  - title: Resource Tags are Manipulated
+    id: CCC.Core.TH13
     description: |
       When resource tags are altered, it can lead to misclassification or
       mismanagement of resources. This can reduce the efficacy of organizational
@@ -451,8 +451,8 @@ threats:
           - reference-id: T1565
             strength: 0 # Not yet specified
             remarks: Data Manipulation
-  - id: CCC.Core.TH14
-    title: Older Resource Versions are Used
+  - title: Older Resource Versions are Used
+    id: CCC.Core.TH14
     description: |
       Running older versions of child resources can expose the system to known
       vulnerabilities that have been addressed in more recent versions. If the
@@ -495,8 +495,8 @@ threats:
           - reference-id: T1489
             strength: 0 # Not yet specified
             remarks: Service Stop
-  - id: CCC.Core.TH15
-    title: Automated Enumeration and Reconnaissance by Non-human Entities
+  - title: Automated Enumeration and Reconnaissance by Non-human Entities
+    id: CCC.Core.TH15
     description: |
       Automated processes may be used to gather details about service and
       child resource elements such as APIs, file systems, or directories.
@@ -515,8 +515,8 @@ threats:
           - reference-id: T1580
             strength: 0 # Not yet specified
             remarks: Cloud Infrastructure Discovery
-  - id: CCC.Core.TH16
-    title: Publications are Disabled
+  - title: Publications are Disabled
+    id: CCC.Core.TH16
     description: |
       Publication of events, metrics, and runtime logs may be disabled, leading
       to a lack of expected security and operational information being shared.
@@ -538,8 +538,8 @@ threats:
           - reference-id: T1562
             strength: 0 # Not yet specified
             remarks: Impair Defenses
-  - id: CCC.Core.TH18
-    title: Encryption Key is Misused
+  - title: Encryption Key is Misused
+    id: CCC.Core.TH18
     description: |
       Encryption keys may be used by an unauthorized entity due to inadequate
       key management practices or the compromise of a connected system. This


### PR DESCRIPTION
Made this shift while I was working on reviewing threats content and it's a game changer. I'm more likely to want to see title values at a glance, and when I need to find an ID I'm likely to just search for it directly.

Non-functional change.