### PR TITLE
change(control): Update CSA CCM mappings in CCC.Core

### DIFF
--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -272,7 +272,9 @@ control-families:
       - id: CCC.Core.C09
         title: Ensure Integrity of Access Logs
         objective: |
-          Ensure that access logs are always recorded to an external location.
+          Ensure that access logs are always recorded to an external location
+          that cannot be manipulated from the context of the service(s) it
+          contains logs for.
         assessment-requirements:
           - id: CCC.Core.C09.TR01
             text: |
@@ -329,11 +331,17 @@ control-families:
           - reference-id: NIST_800_53
             entries:
               - reference-id: AU-9
-          - reference-id: CCM
+          - reference-id: CCMv4
             entries:
               - reference-id: LOG-02
+                remarks: Audit Logs Protection (security and retention)
+                strength: 5
               - reference-id: LOG-04
+                remarks: Audit Logs Access and Accountability (Restrict audit logs access to authorized personnel)
+                strength: 5
               - reference-id: LOG-09
+                remarks: Log Protection (protects audit records from unauthorized access)
+                strength: 5
           - reference-id: ISO_27001
             entries: []
       - id: CCC.Core.C10

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -88,13 +88,23 @@ control-families:
             entries:
               - reference-id: CCC.Core.TH02
         guideline-mappings:
+          - reference-id: CCMv4
+            entries:
+              - reference-id: CEK-03
+                remarks: Data Encryption (in transit and at rest)
+                strength: 5
+              - reference-id: CEK-04
+                remarks: Key Management (use strong encryption)
+                strength: 10
+              - reference-id: IVS-03
+                remarks: Network Security (monitor, encrypt, restrict)
+                strength: 2
+              - reference-id: IVS-07
+                remarks: Migration to Cloud Environments (encrypt when migrating servers)
+                strength: 2
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.DS-02
-          - reference-id: CCM
-            entries:
-              - reference-id: IVS-03
-              - reference-id: IVS-07
           - reference-id: ISO_27001
             entries:
               - reference-id: 2013 A.13.1.1

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -685,9 +685,11 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: DE.AE-3
-          - reference-id: CCM
+          - reference-id: CCMv4
             entries:
               - reference-id: LOG-08
+                remarks: Log Records (Generate audit records containing relevant security information)
+                strength: 5
           - reference-id: ISO_27001
             entries: []
           - reference-id: NIST_800_53

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -628,9 +628,22 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.AC-3
-          - reference-id: CCM
+          - reference-id: CCMv4
             entries:
-              - reference-id: DS-5
+              - reference-id: DSP-01
+                remarks: Security and Privacy Policy and Proceduress
+                strength: 1
+              - reference-id: DSP-07
+                remarks: Data Protection by Design and Default
+                strength: 1
+              - reference-id: DSP-08
+                remarks: Data Privacy by Design and Default
+                strength: 1
+              - reference-id: DSP-10
+                remarks: Sensitive Data Transfer
+                strength: 1
+              - reference-id: DSP-17
+                remarks: Sensitive Data Protection
           - reference-id: ISO_27001
             entries:
               - reference-id: 2013 A.13.1.3

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -88,7 +88,7 @@ control-families:
             entries:
               - reference-id: CCC.Core.TH02
         guideline-mappings:
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: CEK-03
                 remarks: Data Encryption (in transit and at rest)
@@ -202,7 +202,7 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.DS-1
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: DSP-19
                 remarks: Data Location (specify and document processing and backup locations)
@@ -252,7 +252,7 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.PT-5
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: BCR-08
                 remarks: Backup
@@ -331,7 +331,7 @@ control-families:
           - reference-id: NIST_800_53
             entries:
               - reference-id: AU-9
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: LOG-02
                 remarks: Audit Logs Protection (security and retention)
@@ -404,7 +404,7 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.DS-1
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: CEK-03
                 remarks: Data Encryption (in transit and at rest)
@@ -485,7 +485,7 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.DS-1
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: CEK-08
                 remarks: CSC Key Management Capability (must provide the capability to self-manage keys)
@@ -564,7 +564,7 @@ control-families:
             entries:
               - reference-id: CCC.Core.TH01
         guideline-mappings:
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: IAM-14
                 remarks: Strong Authentication (Define, implement and evaluate processes - including MFA)
@@ -656,7 +656,7 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.AC-3
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: DSP-01
                 remarks: Security and Privacy Policy and Proceduress
@@ -726,7 +726,7 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: DE.AE-3
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: LOG-08
                 remarks: Log Records (Generate audit records containing relevant security information)
@@ -781,7 +781,7 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: DE.AE-1
-          - reference-id: CCMv4
+          - reference-id: CCM
             entries:
               - reference-id: LOG-05
                 remarks: Audit Logs Monitoring and Response (take action on detected anomalies)
@@ -789,7 +789,6 @@ control-families:
               - reference-id: SEF-05
                 remarks: Incident Response Metrics (establish and monitor metrics)
                 strength: 3
-              - reference-id: 
           - reference-id: ISO_27001
             entries: []
           - reference-id: NIST_800_53

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -202,10 +202,11 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.DS-1
-          - reference-id: CCM
+          - reference-id: CCMv4
             entries:
-              - reference-id: DSI-06
-              - reference-id: DSI-08
+              - reference-id: DSP-19
+                remarks: Data Location (specify and document processing and backup locations)
+                strength: 10
           - reference-id: ISO_27001
             entries:
               - reference-id: 2013 A.11.1.1

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -485,10 +485,17 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.DS-1
-          - reference-id: CCM
+          - reference-id: CCMv4
             entries:
-              - reference-id: EKM-02
-              - reference-id: EKM-03
+              - reference-id: CEK-08
+                remarks: CSC Key Management Capability (must provide the capability to self-manage keys)
+                strength: 3
+              - reference-id: CEK-10
+                remarks: Key Generation (using industry accepted cryptographic libraries)
+                strength: 10
+              - reference-id: CEK-12
+                remarks: Key Rotation
+                strength: 10
           - reference-id: ISO_27001
             entries:
               - reference-id: 2013 A.10.1.2

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -536,6 +536,11 @@ control-families:
             entries:
               - reference-id: CCC.Core.TH01
         guideline-mappings:
+          - reference-id: CCMv4
+            entries:
+              - reference-id: IAM-14
+                remarks: Strong Authentication (Define, implement and evaluate processes - including MFA)
+                strength: 3
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.AC-7

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -383,8 +383,17 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.DS-1
-          - reference-id: CCM
+          - reference-id: CCMv4
             entries:
+              - reference-id: CEK-03
+                remarks: Data Encryption (in transit and at rest)
+                strength: 5
+              - reference-id: CEK-04
+                remarks: Key Management (use strong encryption)
+                strength: 10
+              - reference-id: UEM-08
+                remarks: Storage Encryption (on managed endpoint devices)
+                strength: 10
               - reference-id: DSP-17
           - reference-id: ISO_27001
             entries: []

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -754,9 +754,15 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: DE.AE-1
-          - reference-id: CCM
+          - reference-id: CCMv4
             entries:
               - reference-id: LOG-05
+                remarks: Audit Logs Monitoring and Response (take action on detected anomalies)
+                strength: 3
+              - reference-id: SEF-05
+                remarks: Incident Response Metrics (establish and monitor metrics)
+                strength: 3
+              - reference-id: 
           - reference-id: ISO_27001
             entries: []
           - reference-id: NIST_800_53

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -252,9 +252,17 @@ control-families:
           - reference-id: NIST-CSF
             entries:
               - reference-id: PR.PT-5
-          - reference-id: CCM
+          - reference-id: CCMv4
             entries:
               - reference-id: BCR-08
+                remarks: Backup
+                strength: 10
+              - reference-id: BCR-10
+                remarks: Disaster Response Plan
+                strength: 1
+              - reference-id: BCR-11
+                remarks: Equipment Redundancy
+                strength: 1
           - reference-id: ISO_27001
             entries: []
           - reference-id: NIST_800_53

--- a/catalogs/core/ccc/controls.yaml
+++ b/catalogs/core/ccc/controls.yaml
@@ -371,7 +371,11 @@ control-families:
           - reference-id: CCM
             entries:
               - reference-id: DSP-10
+                remarks: Sensitive Data Transfer (only processed within scope as permitted)
+                strength: 8
               - reference-id: DSP-19
+                remarks: Data Location (specify and document the physical locations of data)
+                strength: 10
           - reference-id: ISO_27001
             entries: []
           - reference-id: NIST_800_53


### PR DESCRIPTION
This adds mappings to CCMv4, removing references to CCMv3 (v4 contains internal references to v3).

Note that this does not include an update to add the mapping reference data in `metadata.yaml`, which can be taken care of later all at once before we cut the release. 