### PR TITLE
add(ci): Embed applicability categories and CCC.Core ref in metadata

### DIFF
--- a/delivery-toolkit/cmd/catalog-compiler.go
+++ b/delivery-toolkit/cmd/catalog-compiler.go
@@ -37,7 +37,7 @@ var ApplicabilityCategories = []layer2.Category{
 
 var CoreCatalogReference = []layer2.MappingReference{
 	{
-		Id:      "CCC",
+		Id:      "CCC.Core",
 		Title:   "FINOS CCC Core Catalog",
 		Version: "v2025.10",
 	},
@@ -73,8 +73,10 @@ func readAndCompileCatalog() *layer2.Catalog {
 	catalog.Metadata.ApplicabilityCategories = append(
 		catalog.Metadata.ApplicabilityCategories, ApplicabilityCategories...)
 
-	catalog.Metadata.MappingReferences = append(
-		catalog.Metadata.MappingReferences, CoreCatalogReference...)
+	if catalog.Metadata.Id != "CCC.Core" {
+		catalog.Metadata.MappingReferences = append(
+			catalog.Metadata.MappingReferences, CoreCatalogReference...)
+	}
 
 	catalog.Metadata.LastModified = time.Now().Format(time.RFC3339)
 


### PR DESCRIPTION
This will embed definitions of the applicability levels and a reference to the core catalog into every catalog we release without needing to manually maintain those in each directory.

I'll need to hop back in here and add a URL to the released core catalog once that's available.

## Copilot Summary

This pull request adds new metadata enrichment functionality to the catalog compilation process in `delivery-toolkit/cmd/catalog-compiler.go`. The main changes involve automatically appending standard applicability categories, mapping references, and a last-modified timestamp to the catalog metadata during compilation.

**Metadata enrichment:**

* Automatically appends standard applicability categories (`ApplicabilityCategories`) to `catalog.Metadata.ApplicabilityCategories`, providing predefined TLP (Traffic Light Protocol) categories for data classification. [[1]](diffhunk://#diff-929a4960036ea941a2eaf0af6ac742edff7b18a438a3a551bdae5371d2938168R8-R45) [[2]](diffhunk://#diff-929a4960036ea941a2eaf0af6ac742edff7b18a438a3a551bdae5371d2938168R73-R80)
* Adds a core catalog reference (`CoreCatalogReference`) to `catalog.Metadata.MappingReferences`, ensuring consistent catalog versioning and provenance. [[1]](diffhunk://#diff-929a4960036ea941a2eaf0af6ac742edff7b18a438a3a551bdae5371d2938168R8-R45) [[2]](diffhunk://#diff-929a4960036ea941a2eaf0af6ac742edff7b18a438a3a551bdae5371d2938168R73-R80)
* Sets `catalog.Metadata.LastModified` to the current timestamp in RFC3339 format, tracking when the catalog was last compiled.