### PR TITLE
change(ci): fix missing footer in release PDF

### DIFF
--- a/delivery-toolkit/templates/catalog.md
+++ b/delivery-toolkit/templates/catalog.md
@@ -169,3 +169,16 @@ Below is a summary table of the controls, which is then followed by an elucidati
 </div>
 {{- end }}
 {{- end }}
+
+---
+
+## About this Catalog
+
+This document is part of the FINOS Common Cloud Controls project.
+
+- **Project Site**: https://ccc.finos.org
+- **Contribute**: https://github.com/finos/common-cloud-controls
+- **Latest Releases**: https://github.com/finos/common-cloud-controls/releases
+- **License**: Community Specification License 1.0 (see LICENSE in the repository)
+
+Contributions, feedback, and suggestions are welcome. Please open an issue or pull request in the repository.


### PR DESCRIPTION
Caught this oversight in the CCC.Core release candidate.

We did some iterative development toward automated handling of corporate logos, but that wasn't wrapped up and the template was left without a footer. 

This adds a simple signoff to the bottom of the document, so that it doesn't end abruptly after the final control. 