### PR TITLE
change(ci): added group entries so that pre-release trials can commence

### DIFF
--- a/catalogs/ai-ml/gen-ai/capabilities.yaml
+++ b/catalogs/ai-ml/gen-ai/capabilities.yaml
@@ -32,6 +32,7 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.GenAI.CP01
+    group: MachineLearning
     title: Text-Based Model Selection
     description: |
       Ability to select a foundation model that excels at natural language
@@ -39,12 +40,14 @@ capabilities:
       text generation, question answering, and sentiment analysis.
 
   - id: CCC.GenAI.CP02
+    group: MachineLearning
     title: Code-Based Model Selection
     description: |
       Ability to select a foundation model that focuses on code understanding,
       generation, and transformation tasks.
 
   - id: CCC.GenAI.CP03
+    group: MachineLearning
     title: Embedding Model Selection
     description: |
       Ability to select a foundation model used for tasks like semantic
@@ -52,123 +55,145 @@ capabilities:
       vector embeddings.
 
   - id: CCC.GenAI.CP04
+    group: MachineLearning
     title: Image-Based Model Selection
     description: |
       Ability to select a foundation model that focuses on tasks related to vision,
       such as image generation, editing, and manipulation.
 
   - id: CCC.GenAI.CP05
+    group: MachineLearning
     title: Multimodal Model Selection
     description: |
       Ability to select a foundation model that supports more than one modality,
       such as combining text and image.
 
   - id: CCC.GenAI.CP06
+    group: MachineLearning
     title: Customizable Model Selection
     description: |
       Provide users the ability to fine-tune models with their own data.
 
   - id: CCC.GenAI.CP07
+    group: MachineLearning
     title: Parameter Tuning - Temperature
     description: |
       Ability to control the randomness and creativity of the response.
 
   - id: CCC.GenAI.CP08
+    group: MachineLearning
     title: Parameter Tuning - Max Token
     description: |
       Ability to limit the length of the response.
 
   - id: CCC.GenAI.CP09
+    group: MachineLearning
     title: Parameter Tuning - Top P (Nucleus Sampling)
     description: |
       Ability to adjust the number of likely next tokens to consider based on
       cumulative probability.
 
   - id: CCC.GenAI.CP10
+    group: MachineLearning
     title: Parameter Tuning - Top K
     description: |
       Ability to limit the number of token choices for the next word.
 
   - id: CCC.GenAI.CP11
+    group: MachineLearning
     title: Parameter Tuning - Stop Sequences
     description: |
       Ability to halt generation when a predefined sequence is encountered.
 
   - id: CCC.GenAI.CP12
+    group: MachineLearning
     title: Parameter Tuning - Frequency Penalty
     description: |
       Ability to penalize words that have been used frequently, reducing
       their likelihood of being repeated.
 
   - id: CCC.GenAI.CP13
+    group: MachineLearning
     title: Parameter Tuning - Presence Penalty
     description: |
       Ability to penalize tokens that have already been used, encouraging
       the model to introduce new tokens.
 
   - id: CCC.GenAI.CP14
+    group: MachineLearning
     title: Parameter Tuning - Context Length
     description: |
       Ability to control how much prior conversation or input the model will
       use for generating coherent responses.
 
   - id: CCC.GenAI.CP15
+    group: MachineLearning
     title: Text-Based Prompts
     description: |
       Ability to input prompts in plain text.
 
   - id: CCC.GenAI.CP16
+    group: MachineLearning
     title: Structured Prompts
     description: |
       Ability to provide structured input such as JSON as prompts.
 
   - id: CCC.GenAI.CP17
+    group: MachineLearning
     title: Contextual Prompts
     description: |
       Ability to provide context or background information within the prompt
       to guide the response.
 
   - id: CCC.GenAI.CP18
+    group: MachineLearning
     title: Interactive Prompts
     description: |
       Ability to use conversational prompts to create interactive dialogues.
 
   - id: CCC.GenAI.CP19
+    group: MachineLearning
     title: Image-Based Prompts
     description: |
       Ability to input an image as a prompt to generate a response.
 
   - id: CCC.GenAI.CP20
+    group: MachineLearning
     title: Custom Template Prompts
     description: |
       Ability to define custom templates or structures for prompts to
       standardize interactions with the models.
 
   - id: CCC.GenAI.CP21
+    group: MachineLearning
     title: Generate Content
     description: |
       Ability to generate a response given a foundation model, parameter values,
       and a prompt.
 
   - id: CCC.GenAI.CP22
+    group: Data
     title: Data Control
     description: |
       Ensures prompts, model outputs, embeddings, and training data fed by
       customers are not used to train foundation models.
 
   - id: CCC.GenAI.CP23
+    group: Data
     title: Data Storage
     description: |
       Ability to retrieve previously generated outputs and prompts for the
       given session.
 
   - id: CCC.GenAI.CP24
+    group: MachineLearning
     title: Content Moderation
     description: |
       Ensure the service detects and filters abusive, harmful, and sensitive
       information to ensure responsible and safe use of the service.
 
   - id: CCC.GenAI.CP25
+    group: MachineLearning
     title: Plugin Integrations
     description: |
       Ability for the model to use tools to complete a model interaction.

--- a/catalogs/ai-ml/gen-ai/threats.yaml
+++ b/catalogs/ai-ml/gen-ai/threats.yaml
@@ -43,6 +43,7 @@ imported-threats:
 
 threats:
   - id: CCC.GenAI.TH01
+    group: Ingestion
     title: Prompt Injection
     description: |
       Prompt injection may occur when crafted input is used to manipulate the
@@ -122,6 +123,7 @@ threats:
             remarks: LLM Jailbreak
 
   - id: CCC.GenAI.TH02
+    group: Ingestion
     title: Data Poisoning
     description: |
       Data poisoning occurs when training, fine-tuning or embedding data is
@@ -178,6 +180,7 @@ threats:
             remarks: RAG Poisoning
 
   - id: CCC.GenAI.TH03
+    group: Data
     title: Sensitive Information Disclosure
     description: |
       Sensitive data can be memorised by the model from user interaction or
@@ -227,6 +230,7 @@ threats:
             remarks: LLM Data Leakage
 
   - id: CCC.GenAI.TH04
+    group: MachineLearning
     title: Insecure / Unreliable Model Output
     description: |
       A GenAI model may generate content that is incorrect, misleading or
@@ -312,6 +316,7 @@ threats:
             remarks: LLM Response Rendering
 
   - id: CCC.GenAI.TH05
+    group: MachineLearning
     title: Model Overreliance
     description: |
       Model overreliance and misplaced implicit trust in the output of
@@ -357,6 +362,7 @@ threats:
             remarks: LLM Trusted Output Components Manipulation
 
   - id: CCC.GenAI.TH06
+    group: MachineLearning
     title: Unintended Action by a Model-Based Agent
     description: |
       A model-based agent, given the authority to execute tools or interact
@@ -393,6 +399,7 @@ threats:
             remarks: LLM Prompt Crafting
 
   - id: CCC.GenAI.TH07
+    group: Access
     title: Insecure Plugin
     description: |
       A plugin integrated with a GenAI model may contain vulnerabilities
@@ -424,6 +431,7 @@ threats:
             remarks: LLM Plugin Compromise
 
   - id: CCC.GenAI.TH08
+    group: MachineLearning
     title: Model Tampering
     description: |
       Supply chain risks, including tampering with a model's core components
@@ -477,6 +485,7 @@ threats:
             remarks: AI Supply Chain Compromise
 
   - id: CCC.GenAI.TH09
+    group: Observability
     title: Lack of Explainability
     description: |
       The "black box" nature of GenAI models makes it difficult or impossible
@@ -505,6 +514,7 @@ threats:
             remarks: "LLM Trusted Output Components Manipulation: Citations"
 
   - id: CCC.GenAI.TH10
+    group: MachineLearning
     title: Model Version Drift
     description: |
       An update to a managed GenAI model may cause unpredictable and

--- a/catalogs/ai-ml/mlde/capabilities.yaml
+++ b/catalogs/ai-ml/mlde/capabilities.yaml
@@ -26,6 +26,7 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.MLDE.CP01
+    group: MachineLearning
     title: Managed Notebook Environments
     description: |
       Provides fully managed notebook instances specifically designed
@@ -33,6 +34,7 @@ capabilities:
       underlying infrastructure.
 
   - id: CCC.MLDE.CP02
+    group: MachineLearning
     title: Pre-configured Machine Learning Libraries
     description: |
       Offers environments pre-installed with popular machine
@@ -40,6 +42,7 @@ capabilities:
       and Scikit-learn, optimized for ML tasks.
 
   - id: CCC.MLDE.CP03
+    group: MachineLearning
     title: Integrated Experiment Management
     description: |
       Facilitates tracking and management of machine learning
@@ -47,6 +50,7 @@ capabilities:
       within the development environment.
 
   - id: CCC.MLDE.CP04
+    group: MachineLearning
     title: Model Training and Deployment Integration
     description: |
       Supports seamless transition from model development to
@@ -54,6 +58,7 @@ capabilities:
       deployed directly from the MLDE.
 
   - id: CCC.MLDE.CP05
+    group: MachineLearning
     title: Automated Machine Learning (AutoML) Capabilities
     description: |
       Offers AutoML functionalities to automatically build,
@@ -61,12 +66,14 @@ capabilities:
       manual intervention.
 
   - id: CCC.MLDE.CP06
+    group: Compute
     title: GPU/Specialized Hardware Support
     description: |
       Provides access to GPU instances and specialized ML acceleration
       hardware (TPUs, FPGAs) with automated driver and runtime management.
 
   - id: CCC.MLDE.CP07
+    group: Processing
     title: Data Pipeline Integration
     description: |
       Supports integration with data preparation and feature engineering
@@ -74,6 +81,7 @@ capabilities:
       ML experiments.
 
   - id: CCC.MLDE.CP08
+    group: MachineLearning
     title: Model Registry
     description: |
       Provides centralized storage and versioning for trained models,
@@ -81,18 +89,21 @@ capabilities:
       deployment history.
 
   - id: CCC.MLDE.CP09
+    group: MachineLearning
     title: Collaborative Development Support
     description: |
       Enables multiple data scientists to work on the same project with
       version control integration, shared notebooks, and resource management.
 
   - id: CCC.MLDE.CP10
+    group: Observability
     title: Model Monitoring and Drift Detection
     description: |
       Supports monitoring of deployed models for performance degradation,
       data drift, and concept drift with automated alerting capabilities.
 
   - id: CCC.MLDE.CP11
+    group: MachineLearning
     title: Reproducibility Capabilities
     description: |
       Provides capability to capture and version all components needed to
@@ -100,6 +111,7 @@ capabilities:
       configurations.
 
   - id: CCC.MLDE.CP12
+    group: Resource
     title: Resource Scheduling and Optimization
     description: |
       Supports scheduling and optimization of compute resources for
@@ -107,6 +119,7 @@ capabilities:
       capabilities.
 
   - id: CCC.MLDE.CP13
+    group: MachineLearning
     title: Security and Compliance Controls
     description: |
       Provides specific controls for ML workflows including model

--- a/catalogs/app-integration/message/capabilities.yaml
+++ b/catalogs/app-integration/message/capabilities.yaml
@@ -34,94 +34,111 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.Message.CP01
+    group: Messaging
     title: Publish/Subscribe Model
     description: |
       Uses publish/subscribe (pub/sub) messaging service model for
       fan-out distribution of messages to multiple subscribers.
 
   - id: CCC.Message.CP02
+    group: Data
     title: Message Storage Policies
     description: |
       Ability to control the region where messages are stored.
 
   - id: CCC.Message.CP03
+    group: Messaging
     title: Creating Topics and Publish Messages
     description: |
       Ability to create new topics and publish messages to topics
 
   - id: CCC.Message.CP04
+    group: Messaging
     title: List Topics
     description: |
       Ability to to list all existing topics.
 
   - id: CCC.Message.CP05
+    group: Messaging
     title: Edit Topics
     description: |
       Ability to to edit properties of existing topics other than
       the topic name and ordering preference.
 
   - id: CCC.Message.CP06
+    group: Messaging
     title: Delete Topics
     description: |
       Ability to to delete existing topics.
 
   - id: CCC.Message.CP07
+    group: Messaging
     title: Subscribe to Topics and Receive messages
     description: |
       Ability to subscribe to topics and receive messages.
 
   - id: CCC.Message.CP08
+    group: Messaging
     title: List Subscribers
     description: |
       Ability to list all subscribers for a given topics.
 
   - id: CCC.Message.CP09
+    group: Messaging
     title: Edit Subscriber
     description: |
       Ability to edit subscriber properties such as subscription
       filter policies after subscriber is created.
 
   - id: CCC.Message.CP10
+    group: Messaging
     title: Delete Subscribers
     description: |
       Ability to delete subscriber from a given topic.
 
   - id: CCC.Message.CP11
+    group: Messaging
     title: FIFO Message Ordering
     description: |
       Support for first-in, first-out strictly preserved message
       ordering with exactly one message delivered.
 
   - id: CCC.Message.CP12
+    group: Messaging
     title: Best Effort Message Ordering
     description: |
       Support for best-effort message ordering with at-least one
       message delivered.
 
   - id: CCC.Message.CP13
+    group: Messaging
     title: Deduplication of Messages
     description: |
       Support for deduplication of messages with use of messaging
       service capabilities or deduplication IDs.
 
   - id: CCC.Message.CP14
+    group: Messaging
     title: Dead Letter Topics
     description: |
       Supports dead-letter topics for handling messages that cannot be
       delivered or processed.
 
   - id: CCC.Message.CP15
+    group: Access
     title: Access Policies
     description: |
       Ability to specify access policies on publishers and subscribers.
 
   - id: CCC.Message.CP16
+    group: Messaging
     title: Message Filtering
     description: |
       Allows subscribers to receive subset of messages published to the
       subscribed topic based on attributes or content.
 
   - id: CCC.Message.CP17
+    group: Data
     title: Message Retention
     description: |
       Ability to set message retention durations per topic.

--- a/catalogs/compute/batchproc/capabilities.yaml
+++ b/catalogs/compute/batchproc/capabilities.yaml
@@ -36,81 +36,96 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.BatchProc.CP01
+    group: Processing
     title: Data Processing
     description: |
       Processing large volumes of data or time consuming operations in batches (groups)
       without requiring user interaction during execution.
 
   - id: CCC.BatchProc.CP02
+    group: Orchestration
     title: Job Scheduling
     description: |
       Allows workloads to be executed base on a schedules.
 
   - id: CCC.BatchProc.CP03
+    group: Orchestration
     title: Event Triggers
     description: |
       Allows workloads to be executed base on an event.
 
   - id: CCC.BatchProc.CP04
+    group: Orchestration
     title: Manual Triggers
     description: |
       Ability to trigger a job manually when needed.
 
   - id: CCC.BatchProc.CP05
+    group: Resource
     title: Dynamic Resource Allocation
     description: |
       Automatically provision computing resources based on job requirements at the start
       of execution and deallocate them once the job is completed.
 
   - id: CCC.BatchProc.CP06
+    group: Networking
     title: VPC Support
     description: |
       Ability to deploy compute resources in your VPC for network isolation.
 
   - id: CCC.BatchProc.CP07
+    group: Orchestration
     title: Job Definitions
     description: |
       Defines job configurations, including compute resources, environment variables,
       and execution parameters.
 
   - id: CCC.BatchProc.CP08
+    group: Orchestration
     title: Job Queues
     description: |
       Ability to organize jobs into queues with execution priorities.
 
   - id: CCC.BatchProc.CP09
+    group: Orchestration
     title: Job Dependencies
     description: |
       Ability to define dependencies between jobs to execute them in a specific order.
 
   - id: CCC.BatchProc.CP10
+    group: Orchestration
     title: Job Orchestration
     description: |
       Ability to coordinate and manage the execution of multiple jobs to ensure they run
       in order based on conditions to meet performance or business requirements.
 
   - id: CCC.BatchProc.CP11
+    group: Compute
     title: Multinode Parallel Jobs
     description: |
       Support for running HPC (High Performance Computing) workloads that
       span multiple computing instances.
 
   - id: CCC.BatchProc.CP12
+    group: Compute
     title: Array Jobs
     description: |
       Ability to run a single job across multiple data inputs or parameters concurrently.
 
   - id: CCC.BatchProc.CP13
+    group: Compute
     title: Container Support
     description: |
       Native support for containerized workloads using Docker containers.
 
   - id: CCC.BatchProc.CP14
+    group: Orchestration
     title: Retry Policy
     description: |
       Ability to configure retry logic for failed jobs.
 
   - id: CCC.BatchProc.CP15
+    group: Data
     title: Integration with Data Sources and Sinks
     description: |
       Seamlessly integrates with various data sources (for reading inputs) and
@@ -118,17 +133,20 @@ capabilities:
       data streams and data warehouses.
 
   - id: CCC.BatchProc.CP16
+    group: Resource
     title: List Jobs
     description: |
       Ability to list the jobs with their job status such as succeeded, failed,
       running, pending or submitted.
 
   - id: CCC.BatchProc.CP17
+    group: Resource
     title: Cancel Jobs
     description: |
       Ability to cancel jobs that are in submitted, pending or runnable states.
 
   - id: CCC.BatchProc.CP18
+    group: Resource
     title: Terminate Jobs
     description: |
       Ability to terminate jobs that are already running.

--- a/catalogs/compute/serverless-computing/capabilities.yaml
+++ b/catalogs/compute/serverless-computing/capabilities.yaml
@@ -42,12 +42,14 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.SvlsComp.CP01
+    group: Compute
     title: Event Driven Execution
     description: |
       Supports execution of code functions in response to events
       without the need to manage underlying server infrastructure.
 
   - id: CCC.SvlsComp.CP02
+    group: Compute
     title: Event Triggers
     description: |
       Ability to configure event triggers for functions such as
@@ -55,66 +57,78 @@ capabilities:
       and schedules.
 
   - id: CCC.SvlsComp.CP03
+    group: Compute
     title: Stateless Architecture
     description: |
       Functions are stateless and do not retain data or state
       between invocations.
 
   - id: CCC.SvlsComp.CP04
+    group: Compute
     title: Cold Start
     description: |
       New execution environment is created and initialized to process
       an incoming request which is the default behaviour.
 
   - id: CCC.SvlsComp.CP05
+    group: Compute
     title: Warm Start
     description: |
       Ability to reuse of an already-initialized execution environment to
       handle subsequent requests, to reduce invocation latency
 
   - id: CCC.SvlsComp.CP06
+    group: Resource
     title: Flexible Resource Allocation
     description: |
       Ability to control resource allocations such as CPU, memory, and network.
 
   - id: CCC.SvlsComp.CP07
+    group: Compute
     title: Customizable Execution Timeout
     description: |
       Ability to configure function execution timeout for allowing
       short/long-running tasks.
 
   - id: CCC.SvlsComp.CP08
+    group: Compute
     title: Native Runtime Support - Node.js
     description: |
       Support Node.js runtime by default.
 
   - id: CCC.SvlsComp.CP09
+    group: Compute
     title: Native Runtime Support - Python
     description: |
       Support Python runtime by default.
 
   - id: CCC.SvlsComp.CP10
+    group: Compute
     title: Native Runtime Support - Java
     description: |
       Support Java runtime by default.
 
   - id: CCC.SvlsComp.CP11
+    group: Compute
     title: Native Runtime Support - .NET Core
     description: |
       Support .NET runtime by default.
 
   - id: CCC.SvlsComp.CP12
+    group: Compute
     title: Custom Runtimes
     description: |
       Support any language by allowing functions to use custom runtime
 
   - id: CCC.SvlsComp.CP13
+    group: Compute
     title: Environment Variables
     description: |
       Allows setting environment variables for functions to store
       configuration settings and operational parameters.
 
   - id: CCC.SvlsComp.CP14
+    group: Resource
     title: Aliases
     description: |
       Support the use of aliases such as dev, test, prod to manage
@@ -122,6 +136,7 @@ capabilities:
       modifying the function's code.
 
   - id: CCC.SvlsComp.CP15
+    group: Compute
     title: Container Image Support
     description: |
       Ability to deploy and run functions packaged as container images
@@ -129,32 +144,38 @@ capabilities:
       like Docker.
 
   - id: CCC.SvlsComp.CP16
+    group: Resource
     title: Concurrency Limit
     description: |
       Ability to configure a limit for the concurrent executions of a function.
 
   - id: CCC.SvlsComp.CP17
+    group: Resource
     title: Throttling
     description: |
       Incoming requests are throttled when the function exceeds its
       concurrency limit.
 
   - id: CCC.SvlsComp.CP18
+    group: Resource
     title: List Functions
     description: |
       Ability to list all existing functions.
 
   - id: CCC.SvlsComp.CP19
+    group: Resource
     title: Create Functions
     description: |
       Ability to create new functions.
 
   - id: CCC.SvlsComp.CP20
+    group: Resource
     title: Edit Function
     description: |
       Ability to edit an existing function.
 
   - id: CCC.SvlsComp.CP21
+    group: Resource
     title: Delete Function
     description: |
       Ability to delete an existing function.

--- a/catalogs/compute/virtual-machines/capabilities.yaml
+++ b/catalogs/compute/virtual-machines/capabilities.yaml
@@ -40,6 +40,7 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.VM.CP01
+    group: Compute
     title: General Purpose Instances
     description: |
       Provides a computing instance that provides a balance of compute,
@@ -47,6 +48,7 @@ capabilities:
       of applications.
 
   - id: CCC.VM.CP02
+    group: Compute
     title: Compute Optimized Instances
     description: |
       Provides instances that are suited for compute-bound applications that
@@ -54,6 +56,7 @@ capabilities:
       workloads, media transcoding and high performance web servers.
 
   - id: CCC.VM.CP03
+    group: Compute
     title: Memory Optimized Instances
     description: |
       Provides instances that are suited for memory intensive applications
@@ -61,6 +64,7 @@ capabilities:
       big data analytics.
 
   - id: CCC.VM.CP04
+    group: Compute
     title: Storage Optimized Instances
     description: |
       Provides instances that are optimized for applications that require
@@ -69,6 +73,7 @@ capabilities:
       high-frequency online transaction processing (OLTP) systems.
 
   - id: CCC.VM.CP05
+    group: Compute
     title: Accelerated Computing Instances
     description: |
       Provides instances that use hardware accelerator, or co-processors, such
@@ -76,6 +81,7 @@ capabilities:
       graphics processing, or data pattern matching more efficiently.
 
   - id: CCC.VM.CP06
+    group: Compute
     title: Preemptible Instances
     description: |
       Providing the option for using preemptible virtual machine (spot) instances
@@ -83,30 +89,35 @@ capabilities:
       terminated by the cloud provider after a notice period.
 
   - id: CCC.VM.CP07
+    group: Compute
     title: Dedicated Instances
     description: |
       Ability to reserve a physical server dedicated to a single customer
       for regulatory compliance.
 
   - id: CCC.VM.CP08
+    group: Resource
     title: Vertical Scaling
     description: |
       Ability to increase or decrease resources such as cpu, memory, and
       storage of an existing virtual machine instance.
 
   - id: CCC.VM.CP09
+    group: Resource
     title: Horizontal Scaling
     description: |
       Ability to add or remove VM instances assigned to the application to
       handle increased or decreased workload.
 
   - id: CCC.VM.CP10
+    group: Compute
     title: VM Images
     description: |
       Provides templates to create new virtual machines. They usually includes
       operating system, configuration settings and installed applications.
 
   - id: CCC.VM.CP11
+    group: Compute
     title: Custom Images
     description: |
       Ability to create virtual machines with images what are created and owned
@@ -114,12 +125,14 @@ capabilities:
       customer.
 
   - id: CCC.VM.CP12
+    group: Data
     title: Interoperability with Storage Options
     description: |
       Capability to read/write to non-ephemeral external storage including
       object storage and encrypted block storage.
 
   - id: CCC.VM.CP13
+    group: Resource
     title: Patch Management
     description: |
       Offering patch management services and compatibility with third-party
@@ -127,6 +140,7 @@ capabilities:
       with security patches and updates.
 
   - id: CCC.VM.CP14
+    group: Compute
     title: Isolated Secure Environments
     description: |
       Providing an isolated "enclave" within a virtual machine for processing
@@ -136,59 +150,69 @@ capabilities:
       no interactive access, and no external networking.
 
   - id: CCC.VM.CP15
+    group: Compute
     title: Nested Virtualization
     description: |
       Ability to create and manage virtual machines within instances.
 
   - id: CCC.VM.CP16
+    group: Resource
     title: Instance Metadata
     description: |
       Providing metadata about virtual machine instances for configuration
       and management purposes.
 
   - id: CCC.VM.CP17
+    group: Data
     title: Instance Snapshots
     description: |
       Creation of snapshots of virtual machine instances to capture and
       preserve state and data for backup and cloning purposes.
 
   - id: CCC.VM.CP18
+    group: Compute
     title: Instance Templates
     description: |
       Offering templates for provisioning virtual machine instances with
       pre-configured images, instance types, and network configurations.
 
   - id: CCC.VM.CP19
+    group: Compute
     title: Bootstrap Scripts
     description: |
       Ability to provide bootstrap scripts to a VM to run during the
       instance boot process.
 
   - id: CCC.VM.CP20
+    group: Compute
     title: Instance Affinity/Anti-affinity
     description: |
       Enabling control over the location of virtual machine instances to ensure or
       prevent co-location on the same physical hardware.
 
   - id: CCC.VM.CP21
+    group: Observability
     title: Instance Health Checks
     description: |
       Exposing health checks on virtual machine instances so that unhealthy
       instances can be automatically replaced or repaired.
 
   - id: CCC.VM.CP22
+    group: Compute
     title: Instance Remote Access
     description: |
       Offering remote access to virtual machine instances through methods
       such as SSH or RDP for troubleshooting, debugging, and maintenance purposes.
 
   - id: CCC.VM.CP23
+    group: Compute
     title: Instance Live Migration
     description: |
       Ability to perform live migration of virtual machine instances between physical
       hosts for maintenance or load balancing purposes without downtime.
 
   - id: CCC.VM.CP24
+    group: Encryption
     title: TPM Support
     description: |
       Providing support for Trusted Platform Module (TPM) for hardware-based

--- a/catalogs/compute/virtual-machines/threats.yaml
+++ b/catalogs/compute/virtual-machines/threats.yaml
@@ -28,6 +28,7 @@ imported-threats:
 
 threats:
   - id: CCC.VM.TH01
+    group: Resource
     title: Images Contain Vulnerabilities
     description: |
       Virtual machine images may include outdated software, insecure
@@ -44,6 +45,7 @@ threats:
           - reference-id: T1584.001
 
   - id: CCC.VM.TH02
+    group: Access
     title: Instance Metadata is Unprotected
     description: |
       Instance metadata services may be exposed within virtual machines without
@@ -59,6 +61,7 @@ threats:
           - reference-id: T1552.005
 
   - id: CCC.VM.TH03
+    group: Compute
     title: Bootstrap Scripts Introduce Unintended Behavior
     description: |
       Bootstrap scripts executed at startup may include unvalidated commands or
@@ -75,6 +78,7 @@ threats:
           - reference-id: T1059.004
 
   - id: CCC.VM.TH04
+    group: Resource
     title: Instance Templates Propagate Insecure Defaults
     description: |
       Instance templates may contain hardcoded credentials, open ports, or
@@ -90,6 +94,7 @@ threats:
           - reference-id: T1601.002
 
   - id: CCC.VM.TH05
+    group: Networking
     title: Network Access Rules Allow Unintended Communication
     description: |
       Inadequately scoped network access rules may permit communication between
@@ -106,6 +111,7 @@ threats:
           - reference-id: T1071
 
   - id: CCC.VM.TH06
+    group: Access
     title: Remote Access Interfaces Are Insufficiently Restricted
     description: |
       Virtual machine instances may expose remote access methods such as SSH or
@@ -122,6 +128,7 @@ threats:
           - reference-id: T1078
 
   - id: CCC.VM.TH07
+    group: Resource
     title: Resource Starvation Through Preemptible (spot) VM Termination
     description: |
       Workloads running on preemptible (spot) instances may experience unexpected termination
@@ -143,6 +150,7 @@ threats:
             remarks: Service Stop
 
   - id: CCC.VM.TH08
+    group: Data
     title: Co-Residency Risk on Non-Dedicated Infrastructure
     description: |
       Virtual machines operating on shared infrastructure, rather than dedicated instances, may be
@@ -163,6 +171,7 @@ threats:
             remarks: Exploitation for Client Execution
 
   - id: CCC.VM.TH09
+    group: Access
     title: Misconfigured Vertical Scaling Leads to Privilege Escalation
     description: |
       Inadequate permissions or automation logic in vertical scaling processes may allow unauthorized
@@ -184,6 +193,7 @@ threats:
             remarks: "Create or Modify Cloud Compute Infrastructure: Virtual Machine"
 
   - id: CCC.VM.TH10
+    group: Resource
     title: Auto-Scaling Abuse for Resource Exhaustion
     description: |
       Automated horizontal scaling mechanisms may be manipulated through forced load generation, such
@@ -202,6 +212,7 @@ threats:
             remarks: Resource Hijacking
 
   - id: CCC.VM.TH11
+    group: Resource
     title: VM Image Tampering or Poisoning
     description: |
       Virtual machine images may be created or modified to include backdoors, malware, or misconfigurations.

--- a/catalogs/core/ccc/capabilities.yaml
+++ b/catalogs/core/ccc/capabilities.yaml
@@ -1,23 +1,27 @@
 capabilities:
   - id: CCC.Core.CP01
+    group: Encryption
     title: Encryption in Transit Enabled by Default
     description: |
       The service automatically encrypts all data using industry-standard
       cryptographic protocols prior to transmission via a network interface.
 
   - id: CCC.Core.CP02
+    group: Encryption
     title: Encryption at Rest Enabled by Default
     description: |
       The service automatically encrypts all data using industry-standard
       cryptographic protocols prior to being written to a storage medium.
 
   - id: CCC.Core.CP03
+    group: Observability
     title: Access Log Publication
     description: |
       The service automatically publishes structured, verbose records of
       activities performed within the scope of the service by external actors.
 
   - id: CCC.Core.CP04
+    group: Resource
     title: Transaction Rate Limits
     description: |
       The service can throttle, delay, or reject excess requests when
@@ -25,6 +29,7 @@ capabilities:
       provides industry-standard throughput up to that limit.
 
   - id: CCC.Core.CP05
+    group: Access
     title: Signed URLs
     description: |
       The service can generate an ad hoc URL containing authentication
@@ -32,6 +37,7 @@ capabilities:
       a specific component or a child resource.
 
   - id: CCC.Core.CP06
+    group: Access
     title: Access Control
     description: |
       The service automatically enforces user configurations to
@@ -40,6 +46,7 @@ capabilities:
       groups, or attributes.
 
   - id: CCC.Core.CP07
+    group: Observability
     title: Event Publication
     description: |
       The service automatically publishes a structured state-change record
@@ -47,36 +54,42 @@ capabilities:
       components, or child resources.
 
   - id: CCC.Core.CP08
+    group: Data
     title: Data Replication
     description: |
       The service automatically replicates data across multiple deployments
       simultaneously with parity, or may be configured to do so.
 
   - id: CCC.Core.CP09
+    group: Observability
     title: Metrics Publication
     description: |
       The service automatically publishes structured, numeric, time-series data points related to
       the performance, availability, and health of the service or its child resources.
 
   - id: CCC.Core.CP10
+    group: Observability
     title: Log Publication
     description: |
       The service automatically publishes structured, verbose records of activities,
       operations, or events that occur within the service.
 
   - id: CCC.Core.CP11
+    group: Data
     title: Backup
     description: |
       The service can generate copies of its data or configurations
       in the form of automated backups, snapshot-based backups, or incremental backups.
 
   - id: CCC.Core.CP12
+    group: Data
     title: Recovery
     description: |
       The service can be reverted to a previous state
       by providing a compatible backup or snapshot identifier.
 
   - id: CCC.Core.CP14
+    group: Compute
     title: API Access
     description: |
       The service exposes a port enabling external actors to interact
@@ -84,54 +97,63 @@ capabilities:
       protocol methods such as GET, POST, PUT, and DELETE.
 
   - id: CCC.Core.CP15
+    group: Resource
     title: Cost Management
     description: |
       The service monitors data published by child or networked resources to infer
       usage patterns and generate cost reports for the service.
 
   - id: CCC.Core.CP16
+    group: Resource
     title: Budgeting
     description: |
       The service may be configured to take a user-specified action when a
       spending threshold is met or exceeded on a child or networked resource.
 
   - id: CCC.Core.CP17
+    group: Observability
     title: Alerting
     description: |
       The service may be configured to emit a notification based on a user-defined
       condition related to the data published by a child or networked resource.
 
   - id: CCC.Core.CP18
+    group: Data
     title: Resource Versioning
     description: |
       The service automatically assigns versions to child resources which can be used
       to preserve, retrieve, and restore past iterations.
 
   - id: CCC.Core.CP19
+    group: Compute
     title: Child Resource Scaling
     description: |
       The service may be configured to scale child resources automatically
       or on-demand.
 
   - id: CCC.Core.CP20
+    group: Resource
     title: Resource Tagging
     description: |
       The service provides users with the ability to tag a child resource with metadata
       that can be reviewed or queried.
 
   - id: CCC.Core.CP21
+    group: Data
     title: Resource Replication
     description: |
       The service may be configured to replicate child resources
       across multiple deployments.
 
   - id: CCC.Core.CP22
+    group: Data
     title: Location Lock-In
     description: |
       The service may be configured to restrict the deployment of child resources
       to specific geographic locations.
 
   - id: CCC.Core.CP23
+    group: Access
     title: Network Access Rules
     description: |
       The service restricts access to child or networked resources based on
@@ -139,6 +161,7 @@ capabilities:
       protocol, port, or source.
 
   - id: CCC.Core.CP24
+    group: Compute
     title: Core Processing Units
     description: |
       The service provides users and child resources with access to
@@ -146,6 +169,7 @@ capabilities:
       performing computations.
 
   - id: CCC.Core.CP25
+    group: Compute
     title: Random Access Memory Allocation
     description: |
       The service provides users and child resources with access to
@@ -153,12 +177,14 @@ capabilities:
       fast data retrieval during processing tasks.
 
   - id: CCC.Core.CP26
+    group: Compute
     title: Persistent Storage
     description: |
       The service provides users and child resources with access to
       persistent storage for saving and retrieving data reliably over time.
 
   - id: CCC.Core.CP27
+    group: Compute
     title: Configurable Network Ports
     description: |
       The service allows users to configure network ports for
@@ -166,12 +192,14 @@ capabilities:
       and integration with other services.
 
   - id: CCC.Core.CP28
+    group: Compute
     title: Command-line Interface
     description: |
       The service includes a component that reads and translates
       text into commands that can be executed by the service.
 
   - id: CCC.Core.CP29
+    group: Ingestion
     title: Active Ingestion
     description: |
       While running, the service itself can fetch or reach out to
@@ -179,6 +207,7 @@ capabilities:
       for the service to process or operate on.
 
   - id: CCC.Core.CP30
+    group: Ingestion
     title: Passive Ingestion
     description: |
       While running, the service can pause, idle or wait to receive
@@ -186,6 +215,7 @@ capabilities:
       for the service to process or operate on.
   
   - id: CCC.Core.CP31
+    group: Compute
     title: Elastic Scaling
     description: |
       The service automatically adjusts its resource allocation

--- a/catalogs/core/ccc/threats.yaml
+++ b/catalogs/core/ccc/threats.yaml
@@ -1,6 +1,7 @@
 threats:
   - title: Access is Granted to Unauthorized Users
     id: CCC.Core.TH01
+    group: Access
     description: |
       Logic designed to give different permissions to different entities may
       be misconfigured or manipulated, allowing unauthorized entities to access
@@ -44,6 +45,7 @@ threats:
             remarks: Obfuscated Files or Information
   - title: Data is Intercepted in Transit
     id: CCC.Core.TH02
+    group: Data
     description: |
       Data transmitted by the service is susceptible to collection by any entity
       with access to any part of the transmission path. Packet observations can
@@ -63,6 +65,7 @@ threats:
             remarks: Network Sniffing
   - title: Deployment Region Network is Untrusted
     id: CCC.Core.TH03
+    group: Data
     description: |
       Systems are susceptible to unauthorized access or interception by actors
       with social or physical control over the network in which they are
@@ -91,6 +94,7 @@ threats:
             remarks: Adversary-in-the-Middle
   - title: Data is Replicated to Untrusted or External Locations
     id: CCC.Core.TH04
+    group: Data
     description: |
       Systems are susceptible to unauthorized access or interception by actors
       with political or physical control over the network in which they are
@@ -108,6 +112,7 @@ threats:
             remarks: Data Manipulation
   - title: Interference with Replication Processes
     id: CCC.Core.TH05
+    group: Data
     description: |
       Misconfigured or manipulated replication processes may lead to data being
       copied to unintended locations, delayed, modified, or not being copied
@@ -135,6 +140,7 @@ threats:
             remarks: Inhibit System Recovery
   - title: Data is Lost or Corrupted
     id: CCC.Core.TH06
+    group: Data
     description: |
       Services that rely on accurate data are susceptible to disruption in the
       event of data loss or corruption. Any actions that lead to the unintended
@@ -160,6 +166,7 @@ threats:
             remarks: Inhibit System Recovery
   - title: Logs are Tampered With or Deleted
     id: CCC.Core.TH07
+    group: Observability
     description: |
       Tampering or deletion of service logs will reduce the system's ability to
       maintain an accurate record of events. Any actions that compromise the
@@ -184,6 +191,7 @@ threats:
             remarks: Obfuscated Files or Information
   - title: Runtime Metrics are Manipulated
     id: CCC.Core.TH08
+    group: Observability
     description: |
       Manipulation of runtime metrics can lead to inaccurate representations of
       system performance and resource utilization. This compromised data
@@ -204,6 +212,7 @@ threats:
             remarks: Indicator Removal
   - title: Runtime Logs are Read by Unauthorized Entities
     id: CCC.Core.TH09
+    group: Observability
     description: |
       Unauthorized access to logs may expose valuable information about the
       system's configuration, operations, and security mechanisms. This could
@@ -249,12 +258,14 @@ threats:
             remarks: Software Discovery
   - title: Metrics are Read by Unauthorized Entities
     id: CCC.Core.TH19
+    group: Observability
     description: |
       Unauthorized access to runtime metrics may expose valuable information
       about the system's design, performance, and usage patterns. This can
       support the planning of attacks on the service, system, or network.
   - title: State-change Events are Read by Unauthorized Entities
     id: CCC.Core.TH10
+    group: Observability
     description: |
       Unauthorized access to state-change events can reveal information about
       the system's design and usage patterns. This opens the system up to
@@ -282,6 +293,7 @@ threats:
             remarks: File and Directory Discovery
   - title: Publications are Incorrectly Triggered
     id: CCC.Core.TH11
+    group: Resource
     description: |
       Incorrectly triggered publications may disseminate inaccurate
       or misleading information, creating a data integrity risk. Such
@@ -304,6 +316,7 @@ threats:
             remarks: "Data Obfuscation: Junk Data"
   - title: Resource Constraints are Exhausted
     id: CCC.Core.TH12
+    group: Resource
     description: |
       Exceeding the resource constraints through excessive consumption,
       resource-intensive operations, or lowering of rate-limit thresholds
@@ -332,6 +345,7 @@ threats:
             remarks: Network Denial of Service
   - title: Resource Tags are Manipulated
     id: CCC.Core.TH13
+    group: Resource
     description: |
       When resource tags are altered, it can lead to misclassification or
       mismanagement of resources. This can reduce the efficacy of organizational
@@ -350,6 +364,7 @@ threats:
             remarks: Data Manipulation
   - title: Older Resource Versions are Used
     id: CCC.Core.TH14
+    group: Resource
     description: |
       Running older versions of child resources can expose the system to known
       vulnerabilities that have been addressed in more recent versions. If the
@@ -384,6 +399,7 @@ threats:
             remarks: Service Stop
   - title: Automated Enumeration and Reconnaissance by Non-human Entities
     id: CCC.Core.TH15
+    group: Access
     description: |
       Automated processes may be used to gather details about service and
       child resource elements such as APIs, file systems, or directories.
@@ -402,6 +418,7 @@ threats:
             remarks: Cloud Infrastructure Discovery
   - title: Publications are Disabled
     id: CCC.Core.TH16
+    group: Resource
     description: |
       Publication of events, metrics, and runtime logs may be disabled, leading
       to a lack of expected security and operational information being shared.
@@ -422,6 +439,7 @@ threats:
             remarks: Impair Defenses
   - title: Encryption Key is Misused
     id: CCC.Core.TH18
+    group: Resource
     description: |
       Encryption keys may be used by an unauthorized entity due to inadequate
       key management practices or the compromise of a connected system. This
@@ -441,6 +459,7 @@ threats:
             remarks: "Credentials from Password Stores: Cloud Secrets Management Stores"
   - title: Responses are Generated for Unauthorized Requests
     id: CCC.Core.TH17
+    group: Access
     description: |
       The service may generate responses to requests from unauthorized entities.
       This could lead to the exposure of system details, which may be used to

--- a/catalogs/crypto/key/capabilities.yaml
+++ b/catalogs/crypto/key/capabilities.yaml
@@ -27,100 +27,124 @@ imported-capabilities:
         remarks: Active Ingestion
 capabilities:
   - id: CCC.KeyMgmt.CP01
+    group: Encryption
     title: AES-256
     description: |
       Support for the AES-256 Advanced Encryption Standard with a 256-bit key for encryption and decryption.
   - id: CCC.KeyMgmt.CP02
+    group: Encryption
     title: RSA-2048
     description: |
       Supports the RSA algorithm with a key size of 2048 bits for encryption and digital signatures.
   - id: CCC.KeyMgmt.CP03
+    group: Encryption
     title: RSA-3072
     description: |
       Supports the RSA algorithm with a key size of 3072 bits for encryption and digital signatures.
   - id: CCC.KeyMgmt.CP04
+    group: Encryption
     title: RSA-4096
     description: |
       Supports the RSA algorithm with a key size of 4096 bits for encryption and digital signatures.
   - id: CCC.KeyMgmt.CP05
+    group: Encryption
     title: EC-P256
     description: |
       Supports the elliptic curve signing algorithm using the P-256 Curve for digital signatures.
   - id: CCC.KeyMgmt.CP06
+    group: Encryption
     title: EC-P256K
     description: |
       Supports the elliptic curve signing algorithm using the Secp256k1 Curve for digital signatures.
   - id: CCC.KeyMgmt.CP07
+    group: Encryption
     title: EC-P384
     description: |
       Supports the elliptic curve signing algorithm using the P-384 Curve for digital signatures.
   - id: CCC.KeyMgmt.CP08
+    group: Encryption
     title: Key Creation
     description: |
       Supports secure key creation within the key management service using the supported algorithms.
   - id: CCC.KeyMgmt.CP09
+    group: Encryption
     title: Encrypt data
     description: |
       Provides the ability to securely encrypt data using a managed key in the supported encryption algorithms.
   - id: CCC.KeyMgmt.CP10
+    group: Encryption
     title: Decrypt data
     description: |
       Provides the ability to securely decrypt data using a managed key in the supported encryption algorithms.
   - id: CCC.KeyMgmt.CP11
+    group: Encryption
     title: Create Digital Signature
     description: |
       Supports the generation of a digital signature for data using the supported signing algorithms.
   - id: CCC.KeyMgmt.CP12
+    group: Encryption
     title: Verify Digital Signature
     description: |
       Supports the verification of the digital signature of some data using the supported signing algorithms.
   - id: CCC.KeyMgmt.CP13
+    group: Encryption
     title: Supports FIPS 140-2 Level 3
     description: |
       Supports FIPS 140-2 Level 3 certified Hardware Security Modules (HSM).
   - id: CCC.KeyMgmt.CP14
+    group: Encryption
     title: Key Versioning
     description: |
       Provides the ability to manage multiple versions of a key.
   - id: CCC.KeyMgmt.CP15
+    group: Encryption
     title: Key label
     description: |
       Supports the ability to tag a managed key with user defined labels.
   - id: CCC.KeyMgmt.CP16
+    group: Encryption
     title: Disable key
     description: |
       Supports the ability to disable a managed key without deletion.
   - id: CCC.KeyMgmt.CP17
+    group: Encryption
     title: Enable key
     description: |
       Supports the ability to re-enable a disabled managed key.
   - id: CCC.KeyMgmt.CP18
+    group: Encryption
     title: Soft Delete
     description: |
       Supports the ability to prevent the immediate deletion of a managed key. This includes the ability
       to recover accidental deletion of keys within a grace period.
   - id: CCC.KeyMgmt.CP19
+    group: Encryption
     title: Delete Key
     description: |
       Supports the ability to permanently delete a managed key after the grace period defined on soft delete.
   - id: CCC.KeyMgmt.CP20
+    group: Encryption
     title: Automatic Symmetric Key Rotation
     description: |
       Supports the ability to automatically rotate a managed symmetric
       key as long as the key was generated within the KMS.
   - id: CCC.KeyMgmt.CP21
+    group: Encryption
     title: Manual Key Rotation
     description: |
       Supports the ability to manually rotate a managed key.
   - id: CCC.KeyMgmt.CP22
+    group: Encryption
     title: Key Import
     description: |
       Supports the ability to import externally generated keys into the KMS.
   - id: CCC.KeyMgmt.CP23
+    group: Encryption
     title: Key Expiry
     description: |
       Supports the ability to set an expiration date for a key
   - id: CCC.KeyMgmt.CP24
+    group: Encryption
     title: Key Replication
     description: |
       Supports the ability to securely replicate a key across different regions using automated or manual process.

--- a/catalogs/crypto/key/threats.yaml
+++ b/catalogs/crypto/key/threats.yaml
@@ -16,6 +16,7 @@ imported-threats:
 
 threats:
   - id: CCC.KeyMgmt.TH01
+    group: Encryption
     title: |
       Deletion or Disabling of Key Versions Causing Denial of Service or
       Data Loss
@@ -53,6 +54,7 @@ threats:
             remarks: Inhibit System Recovery
 
   - id: CCC.KeyMgmt.TH02
+    group: Encryption
     title: Unrestricted Use of a KMS Key to Decrypt Data
     description: |
       Misconfigured permissions that allow broad invocation of the Decrypt API
@@ -75,6 +77,7 @@ threats:
             remarks: Use Alternate Authentication Material
 
   - id: CCC.KeyMgmt.TH03
+    group: Encryption
     title: Key Rotation is Disabled or Delayed Beyond Policy Limits
     description: |
       Modification of automatic or manual rotation settings can keep older key
@@ -97,6 +100,7 @@ threats:
             remarks: Impair Defenses
 
   - id: CCC.KeyMgmt.TH04
+    group: Encryption
     title: Introduction of Weak or Compromised Key Material During Import
     description: |
       Insufficient validation during the key-import process may allow weak,

--- a/catalogs/crypto/secrets/capabilities.yaml
+++ b/catalogs/crypto/secrets/capabilities.yaml
@@ -32,32 +32,38 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.SecMgmt.CP01 # Secret Storage
+    group: Encryption
     title: Secret Storage
     description: |
       Provides secure storage for sensitive data such as API keys, passwords, certificates, and other secrets.
 
   - id: CCC.SecMgmt.CP02 # Secret Creation - Plaintext
+    group: Encryption
     title: Secret Creation - Plaintext
     description: |
       Ability to create new secrets as basic string data for storing
       sensitive data such as API keys and database credentials.
 
   - id: CCC.SecMgmt.CP03 # Secret Creation - JSON Objects
+    group: Encryption
     title: Secret Creation - JSON Objects
     description: |
       Ability to create new secrets as complex JSON objects with multiple fields for storing sensitive data.
 
   - id: CCC.SecMgmt.CP04 # Secret Creation - Binary Data
+    group: Encryption
     title: Secret Creation - Binary Data
     description: |
       Ability to create new secrets as binary data for storing certificates and private keys.
 
   - id: CCC.SecMgmt.CP05 # Update Secrets
+    group: Encryption
     title: Update Secrets
     description: |
       Ability to update a secret value or description after creation.
 
   - id: CCC.SecMgmt.CP06 # Soft Delete Secrets
+    group: Access
     title: Soft Delete Secrets
     description: |
       Prevent secrets from being deleted immediately. Soft deletion
@@ -65,11 +71,13 @@ capabilities:
       after a recovery window.
 
   - id: CCC.SecMgmt.CP07 # Automatic Secret Rotation
+    group: Access
     title: Automatic Secret Rotation
     description: |
       Supports automatic rotation of secrets based on a defined schedule or triggers to enhance security.
 
   - id: CCC.SecMgmt.CP08 # Secret Replication Policies
+    group: Encryption
     title: Secret Replication Policies
     description: |
       Allows configuration of secret replication policies to control
@@ -77,6 +85,7 @@ capabilities:
       residency requirements.
 
   - id: CCC.SecMgmt.CP09 # Secure Secret Retrieval
+    group: Encryption
     title: Secure Secret Retrieval
     description: |
       Offers a secure API and SDK access for retrieving

--- a/catalogs/database/relational/capabilities.yaml
+++ b/catalogs/database/relational/capabilities.yaml
@@ -50,84 +50,100 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.RDMS.CP01
+    group: Data
     title: SQL Support
     description: |
       Properly handle queries in the SQL language.
 
   - id: CCC.RDMS.CP02
+    group: Data
     title: DB Engine Option - MySQL
     description: |
       Ability to create a MySQL managed relational database.
 
   - id: CCC.RDMS.CP03
+    group: Data
     title: DB Engine Option - PostgreSQL
     description: |
       Ability to create a PostgreSQL managed relational database.
 
   - id: CCC.RDMS.CP04
+    group: Data
     title: DB Engine Option - MariaDB
     description: |
       Ability to create a MariaDB managed relational database.
 
   - id: CCC.RDMS.CP05
+    group: Data
     title: DB Engine Option - SQL Server
     description: |
       Ability to create a Microsoft SQL Server managed relational database.
 
   - id: CCC.RDMS.CP06
+    group: Access
     title: DB Managed Credentials
     description: |
       Ability to managed the database credentials using the cloud
       provider's secret management service.
 
   - id: CCC.RDMS.CP07
+    group: Access
     title: DB Self Managed Credentials
     description: |
       Ability to manage the database credentials by client managed
       username and passwords.
 
   - id: CCC.RDMS.CP08
+    group: Networking
     title: Support for IPv4
     description: |
       Ability to connect to the database using IPv4 addresses.
 
   - id: CCC.RDMS.CP09
+    group: Networking
     title: Support for IPv6
     description: |
       Ability to connect to the database using IPv6 addresses
 
   - id: CCC.RDMS.CP10
+    group: Networking
     title: Public Access
     description: |
       Allow database to be accessed by public internet.
 
   - id: CCC.RDMS.CP11
+    group: Networking
     title: Disable Public Access
     description: |
       Prevent database been accessed by public internet.
 
   - id: CCC.RDMS.CP12
+    group: Networking
     title: Managed Connection Pooling
     description: |
       Ability to configure a managed connection pool for the database.
 
   - id: CCC.RDMS.CP13
+    group: Data
     title: Deletion Protection
     description: |
       Protect the database against accidental deletion.
 
   - id: CCC.RDMS.CP14
+    group: Compute
     title: Dedicated Database Instances
     description: |
       Option to deploy the database on a dedicated instance for
       isolation requirements.
 
   - id: CCC.RDMS.CP15
+    group: Data
     title: Horizontal Scaling
     description: |
       Read replicas of the primary database can be created.
 
   - id: CCC.RDMS.CP16
+    group: Data
     title: Failover
     description: |
       Standby database can be implemented for failover when the

--- a/catalogs/database/relational/threats.yaml
+++ b/catalogs/database/relational/threats.yaml
@@ -49,6 +49,7 @@ imported-threats:
 
 threats:
   - id: CCC.RDMS.TH01
+    group: Access
     title: Unauthorized Access via Default Credentials
     description: |
       If default credentials are not disabled or changed, unauthorized access
@@ -64,6 +65,7 @@ threats:
         entries:
           - reference-id: T1078
   - id: CCC.RDMS.TH02
+    group: Access
     title: Brute Force Attempts on Database Authentication
     description: |
       Repeated attempts to guess database user passwords may be made
@@ -79,6 +81,7 @@ threats:
         entries:
           - reference-id: T1110
   - id: CCC.RDMS.TH03
+    group: Data
     title: Database Backups Stopped
     description: |
       Database backups may be halted, potentially impairing the organization's
@@ -93,6 +96,7 @@ threats:
         entries:
           - reference-id: T1490
   - id: CCC.RDMS.TH04
+    group: Data
     title: Unintentional Database Backup Restoration
     description: |
       A database backup may be restored unintentionally, potentially
@@ -108,6 +112,7 @@ threats:
         entries:
           - reference-id: T1485
   - id: CCC.RDMS.TH05
+    group: Data
     title: Unauthorized Snapshot Sharing
     description: |
       Snapshots may be shared with untrusted accounts, which can lead to

--- a/catalogs/database/vector/capabilities.yaml
+++ b/catalogs/database/vector/capabilities.yaml
@@ -48,72 +48,84 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.Vector.CP01
+    group: Data
     title: Embedding Storage
     description: |
       Supports storage of high-dimensional vector embeddings derived
       from raw input data such as text, images, or audio.
 
   - id: CCC.Vector.CP02
+    group: Data
     title: Vector Indexing
     description: |
       Provides creation and management of indexes optimized for similarity
       search, such as HNSW, IVF, or PQ.
 
   - id: CCC.Vector.CP03
+    group: Data
     title: Similarity Search
     description: |
       Enables nearest-neighbor queries using a query embedding to return
       the most similar vectors from the store.
 
   - id: CCC.Vector.CP04
+    group: Data
     title: Metadata Filtering
     description: |
       Supports structured filtering on metadata fields alongside vector
       similarity search queries.
 
   - id: CCC.Vector.CP05
+    group: Ingestion
     title: Batch Ingestion
     description: |
       Allows for high-throughput batch upload and deletion of vectors and
       associated metadata.
 
   - id: CCC.Vector.CP06
+    group: Data
     title: Real-Time Querying
     description: |
       Provides low-latency response to vector similarity queries suitable
       for interactive applications.
 
   - id: CCC.Vector.CP07
+    group: Resource
     title: Index Lifecycle Management
     description: |
       Enables automated or manual creation, optimization, and removal of
       vector indexes.
 
   - id: CCC.Vector.CP08
+    group: MachineLearning
     title: Embedding Format Compatibility
     description: |
       Supports standard vector formats and integrates with common embedding
       generators (e.g., OpenAI, HuggingFace, TensorFlow).
 
   - id: CCC.Vector.CP09
+    group: Data
     title: Vector Dimension Management
     description: |
       Supports storing and managing vectors of specific or dynamic
       dimensionality, depending on model needs.
 
   - id: CCC.Vector.CP10
+    group: Data
     title: Multi-modal Vector Support
     description: |
       Supports storing and searching across vectors derived from multiple
       modalities (e.g., text, image, audio).
 
   - id: CCC.Vector.CP11
+    group: Access
     title: Query Access Control
     description: |
       Provides the ability to restrict who can run vector similarity or
       metadata filter queries, separate from data modification rights.
 
   - id: CCC.Vector.CP12
+    group: Data
     title: Approximate or Exact Search Modes
     description: |
       Supports both approximate nearest neighbor (ANN) algorithms for speed

--- a/catalogs/database/vector/threats.yaml
+++ b/catalogs/database/vector/threats.yaml
@@ -54,6 +54,7 @@ imported-threats:
         remarks: Unauthorized Network Access via Misconfigured Rules
 threats:
   - id: CCC.Vector.TH01
+    group: Data
     title: Embedding Extraction and Model Inversion
     description: Attackers may infer or reconstruct original data by probing vector
       similarity APIs, especially with unrestricted access. This enables model inversion
@@ -70,6 +71,7 @@ threats:
           - reference-id: AIR-SEC-002
             remarks: Information Leaked to Vector Store
   - id: CCC.Vector.TH02
+    group: Ingestion
     title: Embedding and Index Poisoning
     description: Adversaries may insert malicious or adversarial vectors into the index
       through ingestion endpoints, polluting the dataset and degrading search quality,
@@ -88,6 +90,7 @@ threats:
           - reference-id: AIR-OP-014
             remarks: Inadequate System Alignment
   - id: CCC.Vector.TH03
+    group: Data
     title: Cross-modal or Metadata Leakage
     description: Attackers may infer sensitive information through metadata filters
       or by correlating embeddings across modalities (e.g., voice and face), bypassing
@@ -103,6 +106,7 @@ threats:
           - reference-id: AIR-SEC-002
             remarks: Information Leaked to Vector Store
   - id: CCC.Vector.TH04
+    group: Data
     title: Index Corruption or Downgrade
     description: Attackers with unauthorized access or excessive permissions may tamper
       with or roll back index versions, potentially restoring poisoned data or breaking
@@ -124,6 +128,7 @@ threats:
           - reference-id: T1562
             remarks: Impair Defenses
   - id: CCC.Vector.TH05
+    group: Ingestion
     title: Embedding Format or Dimension Attacks
     description: Poor validation of embedding formats or dimensions can cause service
       crashes or logic errors. This can result in denial of service or incorrect similarity
@@ -143,6 +148,7 @@ threats:
           - reference-id: T1027
             remarks: Obfuscated Files or Information
   - id: CCC.Vector.TH06
+    group: Data
     title: Search Result Manipulation via ANN Bias
     description: Approximate nearest neighbor (ANN) algorithms may yield non-deterministic
       or biased results. Adversaries may exploit these differences to evade detection

--- a/catalogs/database/warehouse/capabilities.yaml
+++ b/catalogs/database/warehouse/capabilities.yaml
@@ -46,6 +46,7 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.DataWar.CP01
+    group: Data
     title: Centralized Data Repository
     description: |
       Acts as a centralized repository where data from various
@@ -53,53 +54,62 @@ capabilities:
       analyze large volumes of data.
 
   - id: CCC.DataWar.CP02
+    group: Data
     title: Optimized Query Performance
     description: |
       Handles complex queries on large datasets efficiently using
       techniques such as indexing and partitioning.
 
   - id: CCC.DataWar.CP03
+    group: Resource
     title: Scalability
     description: |
       Ability to scale with growing data volumes and handle multiple
       queries simultaneously without compromising the performance.
 
   - id: CCC.DataWar.CP04
+    group: Data
     title: Column Storage
     description: |
       Stores data in columns rather than rows for efficient
       data retrieval.
 
   - id: CCC.DataWar.CP05
+    group: Data
     title: SQL Based Querying
     description: |
       Supports SQL based querying on the data sets with specific
       enhancements and optimization for data warehousing.
 
   - id: CCC.DataWar.CP06
+    group: Data
     title: Data Types
     description: |
       Ability to store processed structured and semi-structured
       data optimized for querying and analysis.
 
   - id: CCC.DataWar.CP07
+    group: Processing
     title: Massively Parallel Processing (MPP)
     description: |
       Distributes queries across multiple nodes for increased performance.
 
   - id: CCC.DataWar.CP08
+    group: Data
     title: Materialized Views
     description: |
       Ability to store results of a query into physical tables for faster
       data retrieval and improved query performance for complex queries.
 
   - id: CCC.DataWar.CP09
+    group: Access
     title: Column-Level Security
     description: |
       Allows setting access policies at the column level to
       restrict access to sensitive data fields within tables.
 
   - id: CCC.DataWar.CP10
+    group: Access
     title: Row-Level Security
     description: |
       Enables setting access policies at the row level to
@@ -107,6 +117,7 @@ capabilities:
       on user roles.
 
   - id: CCC.DataWar.CP11
+    group: Ingestion
     title: Integration with Data Sources
     description: |
       Seamless integration with various data sources such as object
@@ -114,6 +125,7 @@ capabilities:
       and data lakes.
 
   - id: CCC.DataWar.CP12
+    group: Processing
     title: Integration with ETL
     description: |
       Integration with services that perform extract, transform and
@@ -122,6 +134,7 @@ capabilities:
       ingestion to the data warehouse using ETL tools.
 
   - id: CCC.DataWar.CP13
+    group: MachineLearning
     title: Integration with ML
     description: |
       Build-in integration with machine learning services for enhanced
@@ -130,6 +143,7 @@ capabilities:
       in data cleansing and transformation for improved data quality as well.
 
   - id: CCC.DataWar.CP14
+    group: Observability
     title: Real-time Metrics Publication
     description: |
       Ability to continuously track and analyze data as it is ingested,
@@ -137,12 +151,14 @@ capabilities:
       scalability and security.
 
   - id: CCC.DataWar.CP15
+    group: Data
     title: Cross-Region Replication
     description: |
       Ability to replicate data to multiple regions for high availability,
       disaster recovery and low-latency access.
 
   - id: CCC.DataWar.CP16
+    group: Data
     title: View Creation and Access
     description: |
       Supports the creation of views (can be logical or material) to abstract

--- a/catalogs/database/warehouse/threats.yaml
+++ b/catalogs/database/warehouse/threats.yaml
@@ -49,6 +49,7 @@ imported-threats:
 
 threats:
   - id: CCC.DataWar.TH01
+    group: Access
     title: Unauthorized Public Access to Datasets
     description: |
       Datasets may be unintentionally made publicly accessible,
@@ -64,6 +65,7 @@ threats:
           - reference-id: T1530
           - reference-id: T1078
   - id: CCC.DataWar.TH02
+    group: Data
     title: Data Exfiltration via Unauthorized Views
     description: |
       Attackers may create or exploit unauthorized views to access sensitive data without proper permissions,
@@ -78,6 +80,7 @@ threats:
           - reference-id: T1020
           - reference-id: T1002
   - id: CCC.DataWar.TH03
+    group: Access
     title: Exposure of Sensitive Data through Inadequate Column-Level Security
     description: |
       Lack of proper column-level security can lead to unauthorized users accessing sensitive data fields,

--- a/catalogs/devtools/build/capabilities.yaml
+++ b/catalogs/devtools/build/capabilities.yaml
@@ -28,66 +28,78 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.Build.CP01
+    group: Orchestration
     title: Build Automation
     description: |
       Provides fully managed continuous integration service that compiles source code,
       run tests and produce software packages based on triggers or schedules.
 
   - id: CCC.Build.CP02
+    group: Orchestration
     title: CI/CD Pipelines
     description: |
       Provides or integrates with continuous integration and continuous delivery/deployment (CI/CD)
       services.
 
   - id: CCC.Build.CP03
+    group: Orchestration
     title: Source Repository Integration
     description: |
       Integrates with cloud native or external source code repositories such as
       GitHub, Bitbucket, GitLab to trigger builds on code changes.
 
   - id: CCC.Build.CP04
+    group: Data
     title: Artifact Storage
     description: |
       Ability to securely store build artifacts for later use.
 
   - id: CCC.Build.CP05
+    group: Orchestration
     title: Multi-language Support
     description: |
       Provides pre-configured build environments for popular programming languages such as Java,
       Python, Node.js, .NET, etc.
 
   - id: CCC.Build.CP06
+    group: Orchestration
     title: Custom Build Environments
     description: |
       Allows custom build environments by specifying the operating system, runtime, or
       providing a custom docker runtime image.
 
   - id: CCC.Build.CP07
+    group: Orchestration
     title: Build Docker Image
     description: |
       Support for building docker container images in the pipelines.
 
   - id: CCC.Build.CP08
+    group: Orchestration
     title: Environment Variables
     description: |
       Ability to set environment variables within the build project.
 
   - id: CCC.Build.CP09
+    group: Orchestration
     title: Concurrent Builds
     description: |
       Support for concurrent, parallel builds to improve build performance.
 
   - id: CCC.Build.CP10
+    group: Orchestration
     title: Caching
     description: |
       Caching of dependencies between builds for faster builds.
 
   - id: CCC.Build.CP11
+    group: Observability
     title: Realtime Build Logs
     description: |
       Providing the ability to monitor builds and view logs in the real-time.
 
   - id: CCC.Build.CP12
+    group: Observability
     title: List and View Builds
     description: |
       Ability to list, view logs and download artifacts of old builds.

--- a/catalogs/devtools/build/threats.yaml
+++ b/catalogs/devtools/build/threats.yaml
@@ -43,6 +43,7 @@ imported-threats:
 
 threats:
   - id: CCC.Build.TH01
+    group: Orchestration
     title: Unauthorized Build Execution
     description: |
       Attackers may trigger builds using unauthorized build agents or external services,
@@ -57,6 +58,7 @@ threats:
         entries:
           - reference-id: T1195
   - id: CCC.Build.TH02
+    group: Access
     title: External Exposure of Build Environments
     description: |
       If build environments have external network access, they may be accessed by unauthorized parties,

--- a/catalogs/devtools/container-registry/capabilities.yaml
+++ b/catalogs/devtools/container-registry/capabilities.yaml
@@ -36,29 +36,34 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.CntrReg.CP01
+    group: Resource
     title: Image Storage
     description: |
       Ability to upload and securely store container images and image metadata.
 
   - id: CCC.CntrReg.CP02
+    group: Access
     title: Private Repositories
     description: |
       Support for creating container image repositories that are restricted and
       only accessible by authorized users or services.
 
   - id: CCC.CntrReg.CP03
+    group: Access
     title: Public Repositories
     description: |
       Support for creating container image repositories that are open to the public.
       These repositories are used mainly for sharing container images.
 
   - id: CCC.CntrReg.CP04
+    group: Resource
     title: Lifecycle Policies
     description: |
       Supports defining of policies for automatic expiry of
       unused or outdated images to manage storage effectively.
 
   - id: CCC.CntrReg.CP05
+    group: Observability
     title: Image Scanning
     description: |
       Provides vulnerability scanning for container images (built-in
@@ -67,17 +72,20 @@ capabilities:
       and Exposures).
 
   - id: CCC.CntrReg.CP06
+    group: Orchestration
     title: Integration with CI/CD Tooling
     description: |
       Seamlessly integrates with CI/CD pipelines to automate pushing and pulling of
       container images.
 
   - id: CCC.CntrReg.CP07
+    group: Resource
     title: Caching of Images
     description: |
       Provides caching for faster access to frequently used images.
 
   - id: CCC.CntrReg.CP08
+    group: Resource
     title: Multi-platform Support
     description: |
       Ability to store images built for different CPU architectures such as
@@ -85,6 +93,7 @@ capabilities:
       repository.
 
   - id: CCC.CntrReg.CP09
+    group: Resource
     title: Immutable Tags
     description: |
       Prevent tags from being overwritten or deleted once they have been
@@ -93,46 +102,54 @@ capabilities:
       the same image throughout its lifetime.
 
   - id: CCC.CntrReg.CP10
+    group: Resource
     title: List Repositories
     description: |
       Ability to list all public and private repositories in the container
       image registry.
 
   - id: CCC.CntrReg.CP11
+    group: Resource
     title: Edit Repository
     description: |
       Ability to edit a public or private container image repository properties
       after being created.
 
   - id: CCC.CntrReg.CP12
+    group: Resource
     title: Delete Repository
     description: |
       Ability to delete a public or private container image repository after
       being created.
 
   - id: CCC.CntrReg.CP13
+    group: Resource
     title: List Images
     description: |
       Ability to list container images in a public or private container image
       repository.
 
   - id: CCC.CntrReg.CP14
+    group: Resource
     title: Delete Image
     description: |
       Ability to delete a container image after being created.
 
   - id: CCC.CntrReg.CP15
+    group: Resource
     title: List Lifecycle Policies
     description: |
       Ability to list lifecycle policies for container images in a public or private
       container repository.
 
   - id: CCC.CntrReg.CP16
+    group: Resource
     title: Edit Lifecycle Policy
     description: |
       Ability to edit a lifecycle policy after being created.
 
   - id: CCC.CntrReg.CP17
+    group: Resource
     title: Delete Lifecycle Policy
     description: |
       Ability to delete a lifecycle policy after being created.

--- a/catalogs/devtools/container-registry/threats.yaml
+++ b/catalogs/devtools/container-registry/threats.yaml
@@ -43,6 +43,7 @@ imported-threats:
 
 threats:
   - id: CCC.CntrReg.TH01
+    group: Resource
     title: Vulnerabilities in Artifacts are Exploited
     description: |
       Attackers exploit known vulnerabilities in container images or artifacts stored in
@@ -57,6 +58,7 @@ threats:
           - reference-id: T1190
           - reference-id: T1195
   - id: CCC.CntrReg.TH02
+    group: Resource
     title: Accumulation of Unused Artifacts
     description: |
       The registry accumulates outdated or unused artifacts, increasing storage

--- a/catalogs/identity/iam/capabilities.yaml
+++ b/catalogs/identity/iam/capabilities.yaml
@@ -24,70 +24,83 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.IAM.CP01
+    group: Access
     title: Global Identities
     description: |
       IAM identities are global across all regions. They are created
       and managed from a single global namespace.
   - id: CCC.IAM.CP02
+    group: Access
     title: IAM Users
     description: |
       Ability to create, manage, list and delete IAM users.
       IAM user represents a single person or application.
   - id: CCC.IAM.CP03
+    group: Access
     title: Long-Term Credentials
     description: |
       Ability to create, manage, list and delete long-term
       credentials such as access keys and service account keys.
   - id: CCC.IAM.CP04
+    group: Access
     title: Password Management
     description: |
       Ability to create, change and delete IAM user passwords.
   - id: CCC.IAM.CP05
+    group: Access
     title: IAM Groups
     description: |
       Ability to create, manage, list and delete IAM groups.
       IAM group is a collection of users, roles or other groups.
   - id: CCC.IAM.CP06
+    group: Access
     title: IAM Roles / Service Principals
     description: |
       Ability to create, manage, list and delete IAM roles.
       IAM role is an identity for applications or services to
       access resources.
   - id: CCC.IAM.CP07
+    group: Access
     title: Managed Identities
     description: |
       Identity assigned to cloud resources (e.g., VMs, Functions) which
       are managed by the cloud vendor.
   - id: CCC.IAM.CP08
+    group: Access
     title: Federated Identity - SAML
     description: |
       Support for user authentication outside the cloud service
       provider using SAML. Authenticated federated identities can
       assume IAM roles.
   - id: CCC.IAM.CP09
+    group: Access
     title: Federated Identity - OIDC
     description: |
       Support for user authentication outside the cloud service
       provider using OIDC. Authenticated federated identities can
       assume IAM roles.
   - id: CCC.IAM.CP10
+    group: Access
     title: Custom Roles
     description: |
       Ability to create, manage, list and delete custom roles.
       Custom roles are user-defined roles that defines what
       actions are allowed.
   - id: CCC.IAM.CP11
+    group: Access
     title: Resource-Level Access
     description: |
       Ability to restrict where actions are allowed, rather than
       the entire service. Defines the scope of the assignment.
   - id: CCC.IAM.CP12
+    group: Access
     title: Policy Conditions
     description: |
       Ability to use conditions to add additional restrictions
       to the permission being granted. Allow access control rules
       to apply only when certain conditions are met.
   - id: CCC.IAM.CP13
+    group: Access
     title: Temporary Credentials
     description: |
       Ability to grant short-lived security credentials that provide
@@ -95,27 +108,32 @@ capabilities:
       are typically issued for a specific session or task and expire
       after a predefined duration.
   - id: CCC.IAM.CP14
+    group: Access
     title: Multi-Factor Authentication (MFA)
     description: |
       Support for enforcing MFA on user accounts and roles. Essential
       for securing root/admin users.
   - id: CCC.IAM.CP15
+    group: Access
     title: Role Assumption / Delegation
     description: |
       Ability to temporarily assume another role or delegate access.
       Commonly used for user impersonation or temporary privilege
       elevation.
   - id: CCC.IAM.CP16
+    group: Access
     title: Access Boundaries
     description: |
       Ability to define a boundary around the maximum effective permissions
       allowed for an identity at a higher level.
   - id: CCC.IAM.CP17
+    group: Access
     title: Deny Permissions by Default
     description: |
       By default, no identity (user, group, role, service) has access to
       any resource, unless explicit permissions are granted.
   - id: CCC.IAM.CP18
+    group: Observability
     title: Audit Tooling
     description: |
       Provide tools to simulate or analyze permission used by a roles,

--- a/catalogs/identity/iam/threats.yaml
+++ b/catalogs/identity/iam/threats.yaml
@@ -25,6 +25,7 @@ imported-threats:
 
 threats:
   - id: CCC.IAM.TH01
+    group: Access
     title: Valid Cloud Credentials Abuse
     description: |
       Valid identity credentials such as access keys, tokens or passwords are misused or
@@ -74,6 +75,7 @@ threats:
             remarks: Brute Force
 
   - id: CCC.IAM.TH02
+    group: Access
     title: Overly-Permissive IAM Policy
     description: |
       An access control policy attached to an identity or a resource is
@@ -109,6 +111,7 @@ threats:
             remarks: "Valid Accounts: Cloud Accounts"
 
   - id: CCC.IAM.TH03
+    group: Access
     title: Overly-Permissive Identity Trust Policy
     description: |
       An IAM role or service principal's trust policy is configured to allow principals
@@ -135,6 +138,7 @@ threats:
             remarks: "Valid Accounts: Cloud Accounts"
 
   - id: CCC.IAM.TH04
+    group: Access
     title: Additional Cloud Credentials Creation
     description: |
       An adversary with access to a sufficiently privileged cloud account may create
@@ -169,6 +173,7 @@ threats:
             remarks: "Account Manipulation: Additional Cloud Credentials"
 
   - id: CCC.IAM.TH05
+    group: Access
     title: Additional IAM Roles Creation
     description: |
       An adversary with access to a sufficiently privileged cloud account may create
@@ -193,6 +198,7 @@ threats:
             remarks: "Account Manipulation: Additional Cloud Roles"
 
   - id: CCC.IAM.TH06
+    group: Access
     title: IAM Policies Modification
     description: |
       An adversary with access to a sufficiently privileged cloud account may modify
@@ -220,6 +226,7 @@ threats:
             remarks: "Modify Authentication Process: Conditional Access Policies"
 
   - id: CCC.IAM.TH07
+    group: Access
     title: Identity Inherits Excessive Permissions Through Group Membership
     description: |
       An identity principal becomes a member of one or more IAM groups, and the combined
@@ -240,6 +247,7 @@ threats:
             remarks: Account Manipulation
 
   - id: CCC.IAM.TH08
+    group: Access
     title: Privilege Escalation via Indirect Role Usage
     description: |
       An identity principal possesses specific, highly privileged permissions, such as the
@@ -267,6 +275,7 @@ threats:
             remarks: "Abuse Elevation Control Mechanism: Temporary Elevated Cloud Access"
 
   - id: CCC.IAM.TH09
+    group: Access
     title: Long-Lived Static Credentials
     description: |
       Long-lived static credentials such as access keys for an identity are used and
@@ -292,6 +301,7 @@ threats:
             remarks: Unsecured Credentials
 
   - id: CCC.IAM.TH10
+    group: Access
     title: Orphaned Federated Identity Retains Access
     description: |
       A federated identity is de-provisioned from the external Identity Provider (IdP),
@@ -316,6 +326,7 @@ threats:
             remarks: Valid Accounts
 
   - id: CCC.IAM.TH11
+    group: Access
     title: Unused Credentials
     description: |
       Unused IAM identity that is no longer needed or monitored remains active. Its compromise
@@ -346,6 +357,7 @@ threats:
             remarks: Unsecured Credentials
 
   - id: CCC.IAM.TH12
+    group: Access
     title: IAM Role is Coerced into Unauthorized Cross-Account Actions (Confused Deputy)
     description: |
       An external actor tricks a legitimate, authorized third-party application into making requests

--- a/catalogs/management/auditlog/capabilities.yaml
+++ b/catalogs/management/auditlog/capabilities.yaml
@@ -23,35 +23,43 @@ imported-capabilities:
         remarks: Alerting
 capabilities:
   - id: CCC.AuditLog.CP01
+    group: Observability
     title: Default Retention Period
     description: |
      Cloud providers support a default minimum retention of audit log data.
   - id: CCC.AuditLog.CP02
+    group: Observability
     title: Export
     description: |
       Support for manual "one off" exporting or downloading of raw log events.
   - id: CCC.AuditLog.CP03
+    group: Observability
     title: Sink
     description: |
       Ability to continually stream audit log data to a hosted storage bucket or data lake solution.
   - id: CCC.AuditLog.CP04
+    group: Observability
     title: Event Types
     description: |
       Audit events are generated with different data types to provide specific fields for the system
       which generated the event, such as Management Event, Data Event and  Policy Event.
   - id: CCC.AuditLog.CP05
+    group: Observability
     title: Time Search
     description: |
       Ability to search for audit events across a specific time range.
   - id: CCC.AuditLog.CP06
+    group: Observability
     title: Filtering
     description: |
       Ability to filter audit events based on specific attribute.
   - id: CCC.AuditLog.CP07
+    group: Observability
     title: Immutable Log Entries
     description: |
       Audit Log events are immutable and cannot be altered or deleted once generated.
   - id: CCC.AuditLog.CP08
+    group: Observability
     title: External Sink
     description: |
       Audit log events can be configured to be sent to a external SIEM or data analysis

--- a/catalogs/management/auditlog/threats.yaml
+++ b/catalogs/management/auditlog/threats.yaml
@@ -22,6 +22,7 @@ imported-threats:
 
 threats:
   - id: CCC.AUDITLOG.TH01
+    group: Observability
     title: Insufficient Audit Logs
     description: |
       If security critical audit events are not logged then it increases the difficulty to detect threats
@@ -40,6 +41,7 @@ threats:
           - reference-id: CWE-778
           - reference-id: CWE-223
   - id: CCC.AUDITLOG.TH02
+    group: Observability
     title: Log Ingestion Latency
     description: |
       Large spikes or sustained delays in log ingestion may degrade the timeliness
@@ -63,6 +65,7 @@ threats:
           - reference-id: CWE-778
           - reference-id: CWE-223
   - id: CCC.AUDITLOG.TH03
+    group: Observability
     title: Sensitive Data Logged
     description: |
       Sensitive information such as  passwords, environment variables,
@@ -96,6 +99,7 @@ threats:
           - reference-id: CWE-532
           - reference-id: CWE-200
   - id: CCC.AUDITLOG.TH04
+    group: Ingestion
     title: Insufficient encoding of audit logs
     description: |
       User-supplied data such as scripts, control characters, escape sequences, or code fragments
@@ -124,6 +128,7 @@ threats:
           - reference-id: CWE-117
           - reference-id: CWE-116
   - id: CCC.AUDITLOG.TH05
+    group: Observability
     title: Logging Evasion via violating size constraints
     description: |
       An attacker can evade detection by intentionally crafting input that violates

--- a/catalogs/management/logging/capabilities.yaml
+++ b/catalogs/management/logging/capabilities.yaml
@@ -28,77 +28,90 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.Logging.CP01
+    group: Observability
     title: Service Log Capture
     description: |
       Ability to capture logs from all relevant cloud services at varying
       levels of verbosity.
 
   - id: CCC.Logging.CP02
+    group: Observability
     title: Application Log Ingestion
     description: |
       Support for ingesting logs from custom applications deployed within the
       cloud environment.
 
   - id: CCC.Logging.CP03
+    group: Observability
     title: Real-Time Log Ingestion
     description: |
       Logs should be ingested in near real-time to enable timely detection and
       response.
 
   - id: CCC.Logging.CP04
+    group: Observability
     title: Centralised Log Collection
     description: |
       Ability to centralise logs from different resources within a signle
       logging solution or platform.
 
   - id: CCC.Logging.CP05
+    group: Observability
     title: Custom Log Format Support
     description: |
       Ability to ingest custom log formats or data from on-premises systems or
       other cloud environments via agents.
 
   - id: CCC.Logging.CP06
+    group: Observability
     title: Log Filtering & Transformation
     description: |
       Ability to to filter, normalise, and transform raw log data at ingestion
       to optimise storage and enhance usability.
 
   - id: CCC.Logging.CP07
+    group: Observability
     title: Immutable Storage
     description: |
       Ability to prevent unauthorized alteration or deletion of logs, ensuring
       their integrity for auditing and forensic purposes.
 
   - id: CCC.Logging.CP08
+    group: Observability
     title: Retention Policies
     description: |
       Ability to define and enforce granular retention periods for different
       log types based on regulatory requirements and internal policies.
 
   - id: CCC.Logging.CP09
+    group: Observability
     title: Internal Sink
     description: |
       Ability to continuously stream log data to a hosted storage bucket or data lake
       solution within the cloud service provider.
 
   - id: CCC.Logging.CP10
+    group: Observability
     title: External Sink
     description: |
       Log events can be configured to be sent to a external SIEM or data analysis
       provider outside of the cloud platform.
 
   - id: CCC.Logging.CP11
+    group: Observability
     title: Log-based Metrics
     description: |
       Ability to extract quantitative metrics from log data for performance
       monitoring and operational analysis.
 
   - id: CCC.Logging.CP12
+    group: Observability
     title: Log Archiving
     description: |
       Ability to archive logs that are no longer needed but must be retained.
 
   - id: CCC.Logging.CP13
+    group: Observability
     title: Field Indexing
     description: |
       Supports field-based indexing to improve log query performace.

--- a/catalogs/management/logging/threats.yaml
+++ b/catalogs/management/logging/threats.yaml
@@ -52,6 +52,7 @@ imported-threats:
 
 threats:
   - id: CCC.Logging.TH01
+    group: Observability
     title: Log Ingestion Performance Degradation
     description: |
       The logging service's ingestion pipeline experiences performance
@@ -83,6 +84,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: "Impair Defenses: Disable Cloud Logs"
   - id: CCC.Logging.TH02
+    group: Data
     title: Unauthorized Data Transfer Out of a Trusted Boundary
     description: |
       Sensitive log data, including PII, financial transaction details,
@@ -116,6 +118,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: Automated Exfiltration
   - id: CCC.Logging.TH03
+    group: Observability
     title: Log Schema or Format Drift
     description: |
       Changes in source application or cloud service log formats, schemas,
@@ -144,6 +147,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: "Impair Defenses: Disable Cloud Logs (can lead to effective disablement)"
   - id: CCC.Logging.TH04
+    group: Observability
     title: Inadequate Log Anonymization/Masking
     description: |
       Sensitive data (e.g., PII, secrets, authentication tokens) is ingested
@@ -172,6 +176,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: Data Manipulation (if attacker is masking their own activity)
   - id: CCC.Logging.TH05
+    group: Observability
     title: Log Retention Policy Evasion or Misconfiguration
     description: |
       Log data is deleted prematurely or retained longer than legally required
@@ -203,6 +208,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: "Impair Defenses: Disable Cloud Logs"
   - id: CCC.Logging.TH06
+    group: Ingestion
     title: Log Injection
     description: |
       User-supplied data such as scripts, control characters, escape sequences,
@@ -233,6 +239,7 @@ threats:
           - reference-id: CWE-117
           - reference-id: CWE-116
   - id: CCC.Logging.TH07
+    group: Observability
     title: Insufficient Logging
     description: |
       If security-critical actions are not logged, it becomes more difficult to

--- a/catalogs/management/monitoring/capabilities.yaml
+++ b/catalogs/management/monitoring/capabilities.yaml
@@ -20,54 +20,65 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.Monitor.CP01
+    group: Observability
     title: Metric collection
     description: |
       Gathering numerical (quantitative) data points about the performance,
       health, or behaviour of systems, applications or infrastructure.
   - id: CCC.Monitor.CP02
+    group: Observability
     title: Tracing
     description: |
       An observability technique providing an end-to-end view of a request or
       transaction flow through a complex system to enable a single action to
       be linked to resulting events in multiple downstream systems.
   - id: CCC.Monitor.CP03
+    group: Observability
     title: Reporting
     description: |
       Summarised view of metrics in a structured, sharable format.
   - id: CCC.Monitor.CP04
+    group: Observability
     title: Health Checks
     description: |
       A type of monitoring that focuses on the operational status and
       readiness of components or entire systems.
   - id: CCC.Monitor.CP05
+    group: Observability
     title: SLO Monitoring
     description: |
       Define and monitor Service Level Objectives (SLO) using Service Level Indicators (SLI) based on metrics.
   - id: CCC.Monitor.CP06
+    group: Observability
     title: Synthetic Monitoring
     description: |
       Proactively checking sample user interactions to identify issues before real users are impacted.
   - id: CCC.Monitor.CP07
+    group: Observability
     title: Uptime Monitoring
     description: |
       Checking whether a specific service or application is accessible from an external perspective.
   - id: CCC.Monitor.CP08
+    group: Observability
     title: Application Performance Monitoring (APM)
     description: |
       A comprehensive approach to monitoring the performance, availability and user experience of
       an application through multiple levels of data collection
   - id: CCC.Monitor.CP09
+    group: Observability
     title: Dashboard
     description: |
       A visual representation of the health of systems being monitored. Pulling together metrics,
       current alerts, SLO/SLI's, health checks and other monitoring features into a single location
       to enable a view of the health of the overall system.
   - id: CCC.Monitor.CP10
+    group: Observability
     title: Triggering
     description: |
       Automatically initiating actions like alerts, notifications or automated workflows based
       on pre-defined conditions being met.
   - id: CCC.Monitor.CP11
+    group: Observability
     title: Integration with Third-Party Tools
     description: |
       Monitoring tools are able to integrate with a number of downstream systems in order to send

--- a/catalogs/management/monitoring/threats.yaml
+++ b/catalogs/management/monitoring/threats.yaml
@@ -28,6 +28,7 @@ imported-threats:
 
 threats:
   - id: CCC.Monitor.TH01
+    group: Observability
     title: Capture Personal Identifiable Information
     description: |
       Unauthorised viewers may get access to PII if it is incorrectly collected by
@@ -55,6 +56,7 @@ threats:
         entries:
           - reference-id: T1589 #Gather Victim Identity Information
   - id: CCC.Monitor.TH02
+    group: Observability
     title: Health Checks Used to Identify Attack Targets
     description: |
       Health Checks are used to inform those responsible for maintaining a system that
@@ -73,6 +75,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: Gather Victim Network Information
   - id: CCC.Monitor.TH03
+    group: Resource
     title: External Monitoring DoS
     description: |
       If an external monitoring service is compromised, it can act as a host for
@@ -94,6 +97,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: Network Denial of Service
   - id: CCC.Monitor.TH04
+    group: Access
     title: External Monitoring Access
     description: |
       If an external monitoring system is compromised, it acts as a trusted external
@@ -112,6 +116,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: External Remote Services
   - id: CCC.Monitor.TH05
+    group: Data
     title: Data Exfiltration Through Tampered Metrics
     description: |
       If a malicious actor is able to make changes to the metrics being collected, it could
@@ -140,6 +145,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: Exfiltration Over Web Service
   - id: CCC.Monitor.TH06
+    group: Resource
     title: Cost Exhaustion Through Tampered Alerts or Metrics Collection
     description: |
       Monitoring systems are expected to generate traffic, but it a malicious actor were to
@@ -162,6 +168,7 @@ threats:
             strength: 0 # Not yet specified
             remarks: Data Manipulation
   - id: CCC.Monitor.TH07
+    group: Compute
     title: Trigger Malicious Code
     description: |
       If a malicious actor is able to create new triggers, they would be able to use valid

--- a/catalogs/management/tracing/capabilities.yaml
+++ b/catalogs/management/tracing/capabilities.yaml
@@ -28,6 +28,7 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.Tracing.CP01
+    group: Observability
     title: Distributed Telemetry Collection
     description: |
       Collects end-to-end telemetry (spans, segments, and trace events) from
@@ -36,6 +37,7 @@ capabilities:
       performance across distributed systems.
 
   - id: CCC.Tracing.CP02
+    group: Observability
     title: Dependency Mapping and Visualization
     description: |
       Automatically builds visual or logical graphs of upstream and
@@ -44,6 +46,7 @@ capabilities:
       signals to clarify how requests traverse the system.
 
   - id: CCC.Tracing.CP03
+    group: Observability
     title: Distributed Context Propagation
     description: |
       Propagates trace and span identifiers across service boundaries using
@@ -51,6 +54,7 @@ capabilities:
       be correlated across asynchronous calls and heterogeneous runtimes.
 
   - id: CCC.Tracing.CP04
+    group: Observability
     title: Performance Profiling
     description: |
       Analyzes trace data to surface runtime characteristics such asexecution
@@ -58,6 +62,7 @@ capabilities:
       granular insight into identifying bottlenecks inside distributed workflows.
 
   - id: CCC.Tracing.CP05
+    group: Observability
     title: Error Correlation
     description: |
       Detects errors, exceptions, faults, and retry patterns within spans and
@@ -65,6 +70,7 @@ capabilities:
       component and operation causing failures.
 
   - id: CCC.Tracing.CP06
+    group: Observability
     title: Sampling
     description: |
       Provides configurable sampling strategies such as rules-based, rate-based,
@@ -72,6 +78,7 @@ capabilities:
       cost and system performance.
 
   - id: CCC.Tracing.CP07
+    group: Observability
     title: Trace Querying & Filtering
     description: |
       Offers a query and filtering interface to retrieve traces by latency,
@@ -79,6 +86,7 @@ capabilities:
       other attributes to isolate behaviours or anomalies quickly.
 
   - id: CCC.Tracing.CP08
+    group: Observability
     title: Integration with Logs and Metrics
     description: |
       Correlates traces with logs and metrics from related resources to
@@ -86,6 +94,7 @@ capabilities:
       using shared identifiers (e.g., trace or span IDs).
 
   - id: CCC.Tracing.CP09
+    group: Observability
     title: Trace Retention
     description: |
       Stores trace data for configurable retention periods and supports
@@ -93,6 +102,7 @@ capabilities:
       compliance requirements.
 
   - id: CCC.Tracing.CP10
+    group: Observability
     title: Assistance for Root Cause Analysis
     description: |
       Analyzes trace patterns, latency anomalies, and error flows to surface

--- a/catalogs/networking/loadbalancer/capabilities.yaml
+++ b/catalogs/networking/loadbalancer/capabilities.yaml
@@ -38,11 +38,13 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.LB.CP01
+    group: Networking
     title: Static Load Balancing
     description: |
       Employ load balancing algorithms that follow fixed rules,
       independent of the current server state.
   - id: CCC.LB.CP02
+    group: Networking
     title: Dynamic Load Balancing
     description: |
       Employ load balancing algorithms that consider the current state
@@ -50,12 +52,14 @@ capabilities:
       distribution in real-time based on the current server health, resource
       utilization, and traffic conditions.
   - id: CCC.LB.CP03
+    group: Networking
     title: Layer 7 Routing
     description: |
       Providing distribution of incoming traffic based on the application layer
       or layer 7 (on ISO model) information. Some of the supported protocols on
       layer 7 are HTTP, HTTPS, HTTP/2, gRPC, and WebSockets.
   - id: CCC.LB.CP04
+    group: Networking
     title: Layer 4 Routing
     description: |
       Providing distribution of incoming traffic based on the
@@ -63,46 +67,55 @@ capabilities:
       the combination of IP addresses and TCP/UDP port to distribute incoming
       traffic rather than inspecting the actual content of the packets.
   - id: CCC.LB.CP05
+    group: Networking
     title: URL-Based Routing
     description: |
       Direct incoming requests to different backend resources based on
       the content of the request URL.
   - id: CCC.LB.CP06
+    group: Networking
     title: HTTP Header-Based Routing
     description: |
       Direct incoming requests to different backend resources based on
       the values of HTTP headers.
   - id: CCC.LB.CP07
+    group: Networking
     title: WebSocket Support
     description: |
       Ability to support web socket communication.
   - id: CCC.LB.CP08
+    group: Networking
     title: Dual-stack Load Balancing
     description: |
       Ability to support traffic originated from both IPv4 and IPv6.
   - id: CCC.LB.CP09
+    group: Resource
     title: Load Balancer Autoscaling
     description: |
       Ability for the load balancer to dynamically adjust its capacity
       in response to fluctuations in incoming traffic.
   - id: CCC.LB.CP10
+    group: Resource
     title: Target Autoscaling
     description: |
       Ability for the load balancer to trigger scaling actions of the
       backend instances (targets) to handle fluctuations in incoming traffic.
   - id: CCC.LB.CP11
+    group: Encryption
     title: SSL/TLS Termination
     description: |
       Process of decrypting SSL or TLS encrypted traffic at the load balancer
       level rather than at the backend servers. This allows the load balancer
       to offload the decryption task from the backend servers.
   - id: CCC.LB.CP12
+    group: Observability
     title: Target Health Checks
     description: |
       Ability to continuously perform health checks on backend backend targets
       in form of checking the response to HTTP request, TCP connection or checking
       other application-specific parameter
   - id: CCC.LB.CP13
+    group: Networking
     title: Health Checks-based Target Removal
     description: |
       If the health check detects that a backend target is unhealthy
@@ -110,35 +123,42 @@ capabilities:
       of available backend instances. This ensures that traffic is no longer
       routed to the unhealthy target.
   - id: CCC.LB.CP14
+    group: Networking
     title: Retries
     description: |
       Ability to retry delivery of failed requests to targets. The conditions
       under which the load balancer retries, how long to wait before retrying,
       and the maximum number of retries permitted are configurable.
   - id: CCC.LB.CP15
+    group: Networking
     title: Session Affinity
     description: |
       Can configure subsequent requests from an initial client to be
       passed to the same target.
   - id: CCC.LB.CP16
+    group: Networking
     title: URL Redirects
     description: |
       Redirect incoming traffic to a different URL or location.
   - id: CCC.LB.CP17
+    group: Networking
     title: URL Rewrites
     description: |
       Rewrite URL paths before forwarding them to backend services.
   - id: CCC.LB.CP18
+    group: Networking
     title: Custom Response
     description: |
       Ability to configure specific HTTP responses to be returned by
       the load balancer under defined conditions.
   - id: CCC.LB.CP19
+    group: Networking
     title: Request and Response Header Transformations
     description: |
       Ability to modify HTTP headers of both incoming requests and outgoing
       responses.
   - id: CCC.LB.CP20
+    group: Networking
     title: Traffic Splitting / Weighted Routing
     description: |
       Can distribute incoming traffic across multiple backend resources
@@ -146,17 +166,20 @@ capabilities:
       deployments, A/B testing, blue-green deployments, or gradual
       traffic migrations).
   - id: CCC.LB.CP21
+    group: Networking
     title: Traffic Mirroring
     description: |
       Can duplicate incoming network traffic and send it to a secondary
       destination for monitoring, analysis, or testing purposes.
   - id: CCC.LB.CP22
+    group: Networking
     title: Rate Limiting / Throttling
     description: |
       Ability to limit the number of requests per second per client. This
       ensures that no single client or user overloads the backend servers,
       distributing requests fairly across multiple instances.
   - id: CCC.LB.CP23
+    group: Networking
     title: Firewall Integration
     description: |
       Ability to seamlessly integrate with firewall services to ensure only

--- a/catalogs/networking/loadbalancer/threats.yaml
+++ b/catalogs/networking/loadbalancer/threats.yaml
@@ -28,6 +28,7 @@ imported-threats:
 
 threats:
   - id: CCC.LB.TH01
+    group: Resource
     title: Unrestricted Request Traffic Overwhelms Downstream Services
     description: |
       Absence of filtering or rate limiting permits malicious traffic to
@@ -54,6 +55,7 @@ threats:
             remarks: Brute Force
 
   - id: CCC.LB.TH03
+    group: Networking
     title: Traffic Distribution Is Manipulated
     description: |
       Adjusting distribution policies can concentrate traffic on specific nodes
@@ -74,6 +76,7 @@ threats:
           - reference-id: T1557
 
   - id: CCC.LB.TH04
+    group: Access
     title: Session Persistence Is Exploited
     description: |
       Improper session-affinity settings can enable session fixation or
@@ -91,6 +94,7 @@ threats:
           - reference-id: T1557
 
   - id: CCC.LB.TH05
+    group: Resource
     title: Health Checks Are Exploited to Take Services Offline
     description: |
       Manipulating health-check endpoints or responses can cause healthy
@@ -111,6 +115,7 @@ threats:
           - reference-id: T1583
 
   - id: CCC.LB.TH06
+    group: Data
     title: Sensitive Metadata Exposure via HTTP Headers
     description: |
       Response headers may reveal software versions, internal IPs, or other
@@ -126,6 +131,7 @@ threats:
           - reference-id: T1530
 
   - id: CCC.LB.TH07
+    group: Encryption
     title: TLS Certificates Are Expired or Invalid
     description: |
       Stale or untrusted certificates weaken encrypted-traffic protection.

--- a/catalogs/networking/vpc/capabilities.yaml
+++ b/catalogs/networking/vpc/capabilities.yaml
@@ -18,97 +18,114 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.VPC.CP01
+    group: Networking
     title: Isolated Custom Network Creation
     description: |
       Ability to create a virtual network that is isolated from other users of the same
       public cloud.
 
   - id: CCC.VPC.CP02
+    group: Networking
     title: IPv4 CIDR Block
     description: |
       Ability to specify a IPv4 CIDR block to the virtual network.
 
   - id: CCC.VPC.CP03
+    group: Networking
     title: IPv6 CIDR Block
     description: |
       Ability to specify a IPv6 CIDR block to the virtual network.
 
   - id: CCC.VPC.CP04
+    group: Networking
     title: Public Subnet Creation
     description: |
       Ability to create a subnet that allows resources within the subnet to
       communicate with the public internet.
 
   - id: CCC.VPC.CP05
+    group: Networking
     title: Private Subnet Creation
     description: |
       Ability to create a subnet that resources within the subnet cannot directly
       access the public internet.
 
   - id: CCC.VPC.CP06
+    group: Networking
     title: Multiple Availability Zones for Subnets
     description: |
       Ability to spread the subnets in more than one availability zones.
 
   - id: CCC.VPC.CP07
+    group: Networking
     title: Routing Control
     description: |
       Ability to control traffic within the VPC and between the VPC and the
       internet or on-premises networks using customizable route tables.
 
   - id: CCC.VPC.CP08
+    group: Networking
     title: Connectivity Options - Internet Gateway
     description: |
       Enables direct internet access for resources within a VPC.
 
   - id: CCC.VPC.CP09
+    group: Networking
     title: Connectivity Options - NAT Gateways
     description: |
       Allows instances in private subnets to access the internet without
       exposing them to inbound internet traffic.
 
   - id: CCC.VPC.CP10
+    group: Networking
     title: Connectivity Options - Private Connection
     description: |
       Dedicated, private, high-speed connections between on-premises
        networks and cloud VPC.
 
   - id: CCC.VPC.CP11
+    group: Networking
     title: Connectivity Options - VPC Peering
     description: |
       Establishing a private connection between two VPCs to
       communicate seamlessly.
 
   - id: CCC.VPC.CP12
+    group: Networking
     title: Connectivity Options - Transit Gateways
     description: |
       A hub-and-spoke model for connecting multiple VPCs and
       on-premises networks.
 
   - id: CCC.VPC.CP13
+    group: Networking
     title: Connectivity Options - Site-to-site VPN
     description: |
       Provides an encrypted connection over the internet between
       a VPC and an on-premises network.
 
   - id: CCC.VPC.CP14
+    group: Networking
     title: Built-in DNS Resolution
     description: |
       Resolves hostnames to IP addresses for instances within the VPC
        allowing instances to communicate using hostnames instead of IP addresses.
 
   - id: CCC.VPC.CP15
+    group: Networking
     title: Built-in DHCP Resolution
     description: |
       Automatically assign IP addresses, subnet masks, default gateways
       and other network configurations to instances within the VPC.
 
   - id: CCC.VPC.CP16
+    group: Observability
     title: Flow Logs
     description: |
       Ability to capture information about the IP traffic going through the VPC.
 
   - id: CCC.VPC.CP17
+    group: Networking
     title: VPC Endpoints
     description: |
       Ability to allow secure, private connectivity between resources within a VPC

--- a/catalogs/networking/vpc/threats.yaml
+++ b/catalogs/networking/vpc/threats.yaml
@@ -28,6 +28,7 @@ imported-threats:
 
 threats:
   - id: CCC.VPC.TH01
+    group: Networking
     title: Unauthorized Access via Insecure Default Networks
     description: |
       Default network configurations may include insecure settings and open
@@ -42,6 +43,7 @@ threats:
         entries:
           - reference-id: T1040
   - id: CCC.VPC.TH02
+    group: Networking
     title: Exposure of Resources to Public Internet
     description: |
       Assignment of external IP addresses to resources exposes resources to the
@@ -57,6 +59,7 @@ threats:
           - reference-id: T1133
           - reference-id: T1078
   - id: CCC.VPC.TH03
+    group: Networking
     title: Unauthorized Network Access Through VPC Peering
     description: |
       Unauthorized VPC peering connections can allow network traffic between
@@ -71,6 +74,7 @@ threats:
         entries:
           - reference-id: T1599
   - id: CCC.VPC.TH04
+    group: Observability
     title: Lack of Network Visibility due to Disabled VPC Flow Logs
     description: |
       VPC subnets with disabled flow logs lack critical network traffic
@@ -86,6 +90,7 @@ threats:
         entries:
           - reference-id: T1562
   - id: CCC.VPC.TH05
+    group: Networking
     title: Overly Permissive VPC Endpoint Policies
     description: |
       VPC Endpoint policies that are overly permissive may inadvertently expose

--- a/catalogs/orchestration/etl/capabilities.yaml
+++ b/catalogs/orchestration/etl/capabilities.yaml
@@ -32,66 +32,77 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.ETL.CP01
+    group: Processing
     title: Batch Processing
     description: |
       Supports the processing of bounded (batch) data sources
       using a consistent programming model or engine.
   
   - id: CCC.ETL.CP02
+    group: Processing
     title: Stream Processing
     description: |
       Supports the processing of unbounded (streaming) data sources
       using a consistent programming model or engine.
 
   - id: CCC.ETL.CP03
+    group: Processing
     title: Schema Evolution
     description: |
       Automatically detects source data structures and manages changes in
       schema (e.g., column additions) over time without pipeline failure.
 
   - id: CCC.ETL.CP04
+    group: Processing
     title: Distributed Data Shuffling
     description: |
       Provides an internal service to re-partition and group data across
       distributed workers for complex operations like joins and aggregations.
 
   - id: CCC.ETL.CP05
+    group: Processing
     title: Windowing and Event-Time Processing
     description: |
       Enables grouping of data based on time attributes, supporting tumbling,
       hopping, and session windows with late-data handling (watermarking).
 
   - id: CCC.ETL.CP06
+    group: Ingestion
     title: Change Data Capture (CDC) Integration
     description: |
       Supports incremental data ingestion by tracking changes in source
       transaction logs rather than full table scans.
 
   - id: CCC.ETL.CP07
+    group: Ingestion
     title: Connectivity and Connector Library
     description: |
       Provides pre-built, managed connectors for a variety of sources and
       sinks (e.g., Object Storage, RDBMS, NoSQL, Pub/Sub).
 
   - id: CCC.ETL.CP08
+    group: Processing
     title: Job Bookmarks
     description: |
       Persists the state of a processing job (e.g., checkpointing or bookmarks)
       to ensure exactly-once processing and fault tolerance.
 
   - id: CCC.ETL.CP09
+    group: Processing
     title: Pushdown Optimization
     description: |
       The ability to translate transformation logic into the native language
       of the source or sink (e.g., SQL) to minimize data movement.
 
   - id: CCC.ETL.CP10
+    group: Orchestration
     title: Visual Orchestration
     description: |
       Provides a graphical interface to define dependencies
       between extraction, transformation, and loading tasks.
 
   - id: CCC.ETL.CP11
+    group: Processing
     title: Data Lineage & Metadata Tracking
     description: |
       Captures and exports metadata regarding the data sources,
@@ -99,17 +110,20 @@ capabilities:
       flow from source to destination for compliance and debugging.
 
   - id: CCC.ETL.CP12
+    group: Processing
     title: User-Defined Function (UDF) Support
     description: |
       Allows developers to inject custom logic (Python, Java, SQL) into the
       managed processing pipeline for complex transformations.
 
   - id: CCC.ETL.CP13
+    group: Orchestration
     title: Time-Based Job Triggering
     description: |
       Supports time-based (cron) mechanisms to initiate data processing workflows.
 
   - id: CCC.ETL.CP14
+    group: Orchestration
     title: Event Based Job Triggering
     description: |
       Supports event-based (file arrival) mechanisms to initiate

--- a/catalogs/orchestration/k8s/capabilities.yaml
+++ b/catalogs/orchestration/k8s/capabilities.yaml
@@ -32,12 +32,14 @@ imported-capabilities:
 
 capabilities:
   - id: CCC.K8S.F01
+    group: Orchestration
     title: Managed Kubernetes Control Plane
     description: |
       Provides a fully managed Kubernetes control plane that has
       high availability, with automatic updates and patching.
 
   - id: CCC.K8S.F02
+    group: Orchestration
     title: Managed Node Pool
     description: |
       Provides fully managed Kubernetes worker nodes (compute resources).
@@ -45,54 +47,63 @@ capabilities:
       by the service.
 
   - id: CCC.K8S.F03
+    group: Compute
     title: Virtual Nodes
     description: |
       Ability to have fully managed virtual compute resources to power Kubernetes
       worker nodes. This will eliminate the need to manage underlying nodes.
 
   - id: CCC.K8S.F04
+    group: Compute
     title: GPU Support
     description: |
       Support for GPU-accelerated workloads through integration of GPUs,
       enabling high-performance computing.
 
   - id: CCC.K8S.F05
+    group: Orchestration
     title: OCI Container Image Execution
     description: |
       Supports running containerized workloads using OCI-compliant images,
       providing an isolated execution environment for applications.
 
   - id: CCC.K8S.F06
+    group: Orchestration
     title: Container Registry Integration
     description: |
       Enables integration with public or private container registries to
       retrieve container images for execution.
 
   - id: CCC.ContOrch.F07
+    group: Data
     title: Storage Integration
     description: |
       Supports attaching ephemeral or persistent storage volumes to running containers
       in the Kubernetes cluster.
 
   - id: CCC.K8S.F08
+    group: Networking
     title: Built-in Ingress Load Balancing
     description: |
       Built-in support for distributes incoming traffic across running container
       instances to optimize resource usage and availability.
 
   - id: CCC.ContOrch.F09
+    group: Resource
     title: Cluster Auto Scaling
     description: |
       Ability to automatically scale the number of worker nodes in the cluster
       based on workload demand, ensuring efficient resource utilization.
 
   - id: CCC.K8S.F10
+    group: Networking
     title: Private Cluster Endpoints
     description: |
       Ability to restrict access to the Kubernetes API server to private networks,
       ensuring the control plane is only accessible within your VPC.
 
   - id: CCC.K8S.F11
+    group: Networking
     title: Service Mesh Integration
     description: |
       Ability to integrate with managed service mesh offering by the cloud
@@ -100,6 +111,7 @@ capabilities:
       and security.
 
   - id: CCC.K8S.F12
+    group: Access
     title: Secrets Integration
     description: |
       Ability to seamlessly integrate with cloud native secret manager service
@@ -107,6 +119,7 @@ capabilities:
       or certificates, within Kubernetes workloads.
 
   - id: CCC.K8S.F13
+    group: Observability
     title: Observability Tooling Integration
     description: |
       Ability integrate with Observability tooling such as Prometheus and Grafana


### PR DESCRIPTION
This adds groups that were generated by Claude, for the purpose of unblocking release pipeline trials. We plan to give each catalog a final review prior to each release, so these are not intended to be bulletproof at this time.