### PR TITLE
change(ci): remove our customizations to semantic pr title requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,60 @@
+<!--
+=============================================================================
+  Thanks for contributing to Common Cloud Controls!
+
+  This whole block is a guide for you, the PR author. It will NOT appear in
+  the rendered PR description because it is inside an HTML comment. Read it,
+  use it, then leave it in place (or remove it — either is fine, since it is
+  invisible to readers).
+
+  Only the visible sections below the closing `-->` are part of your PR
+  description. Replace the placeholder text in those sections with your own.
+-----------------------------------------------------------------------------
+
+  PR TITLE FORMAT
+  ---------------
+  PR titles must follow the Conventional Commits specification, or CI will
+  fail:
+
+      <type>: <short description>
+
+  Additional scope information is optional for quickly searching later:
+
+      <type>(<scope>): <short description>
+
+  COMMON TYPES
+  ------------
+    feat      new feature
+    fix       bug fix
+    docs      documentation
+    chore     maintenance
+    refactor  code restructuring (no behavior change)
+    test      tests
+    ci        CI/CD changes
+
+  The full Conventional Commits set is accepted:
+    feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+
+  EXAMPLES
+  --------
+    feat: add threat catalog export for OSCAL
+    fix: handle empty capability list in renderer
+    docs: clarify release workflow in CONTRIBUTING
+    ci: pin action-semantic-pull-request to v5
+
+  See: https://www.conventionalcommits.org/
+=============================================================================
+-->
+
+## Summary
+
+<!-- Replace this comment with a description of what this PR changes, and why. -->
+
+## Related issues
+
+<!-- Replace this comment with issue references, e.g. `Closes #123`. Delete the section if none apply. -->
+
+## Checklist
+
+- [ ] PR title follows the Conventional Commits format (see the guide at the top of this template)
+- [ ] Tests / docs updated as needed

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -20,19 +20,3 @@ jobs:
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            add
-            change
-            remove
-            fix
-          scopes: |
-            ci
-            docs
-            capability
-            threat
-            control
-            category
-            family
-            arch
-          requireScope: true


### PR DESCRIPTION
We got creative a while back and tried customizing the PR title requirements, but the customized requirements never became habit or intuitive even for maintainers. This restores the normal semantic pr title requirements (ci, feat, docs, fix, etc)