### PR TITLE
fix: Add CODEOWNERS entry for website directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,3 +18,5 @@ services/service-families.yaml @finos/ccc-wg-taxonomy
 **/*.feature @finos/ccc-wg-security
 
 /docs/governance/working-groups/communications @finos/ccc-wg-communications @finos/ccc-steerco
+
+/website @finos/ccc-wg-website


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file, assigning ownership of the `/website` directory to the `@finos/ccc-wg-website` team.
