### PR TITLE
fix: scaffold missing controls and threats stubs for tracing, etl, k8s

### DIFF
--- a/catalogs/management/tracing/controls.yaml
+++ b/catalogs/management/tracing/controls.yaml
@@ -1,0 +1,21 @@
+imported-controls:
+  - reference-id: CCC
+    entries:
+      - reference-id: CCC.Core.CN01
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN02
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN03
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN04
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN05
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN06
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN07
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN09
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN11
+        strength: 0 # Not yet specified

--- a/catalogs/management/tracing/threats.yaml
+++ b/catalogs/management/tracing/threats.yaml
@@ -1,0 +1,48 @@
+imported-threats:
+  - reference-id: CCC
+    entries:
+      - reference-id: CCC.Core.TH01
+        strength: 0 # Not yet specified
+        remarks: Access control is misconfigured
+      - reference-id: CCC.Core.TH02
+        strength: 0 # Not yet specified
+        remarks: Data is intercepted in transit
+      - reference-id: CCC.Core.TH03
+        strength: 0 # Not yet specified
+        remarks: Deployment region network is untrusted
+      - reference-id: CCC.Core.TH04
+        strength: 0 # Not yet specified
+        remarks: Data is replicated to untrusted or external locations
+      - reference-id: CCC.Core.TH05
+        strength: 0 # Not yet specified
+        remarks: Data is corrupted during replication
+      - reference-id: CCC.Core.TH06
+        strength: 0 # Not yet specified
+        remarks: Data is lost or corrupted
+      - reference-id: CCC.Core.TH07
+        strength: 0 # Not yet specified
+        remarks: Logs are Tampered With or Deleted
+      - reference-id: CCC.Core.TH08
+        strength: 0 # Not yet specified
+        remarks: Cost Management Data is Manipulated
+      - reference-id: CCC.Core.TH09
+        strength: 0 # Not yet specified
+        remarks: Logs or Monitoring Data are Read by Unauthorized Users
+      - reference-id: CCC.Core.TH10
+        strength: 0 # Not yet specified
+        remarks: Alerts are Intercepted
+      - reference-id: CCC.Core.TH11
+        strength: 0 # Not yet specified
+        remarks: Event Notifications are Incorrectly Triggered
+      - reference-id: CCC.Core.TH12
+        strength: 0 # Not yet specified
+        remarks: Resource constraints are exhausted
+      - reference-id: CCC.Core.TH13
+        strength: 0 # Not yet specified
+        remarks: Resource Tags Are Manipulated
+      - reference-id: CCC.Core.TH14
+        strength: 0 # Not yet specified
+        remarks: Older Resource Versions Are Exploited
+      - reference-id: CCC.Core.TH15
+        strength: 0 # Not yet specified
+        remarks: Automated Enumeration and Reconnaissance by Non-Human Entities

--- a/catalogs/orchestration/etl/controls.yaml
+++ b/catalogs/orchestration/etl/controls.yaml
@@ -1,0 +1,21 @@
+imported-controls:
+  - reference-id: CCC
+    entries:
+      - reference-id: CCC.Core.CN01
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN02
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN03
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN04
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN05
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN06
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN07
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN09
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN11
+        strength: 0 # Not yet specified

--- a/catalogs/orchestration/etl/threats.yaml
+++ b/catalogs/orchestration/etl/threats.yaml
@@ -1,0 +1,48 @@
+imported-threats:
+  - reference-id: CCC
+    entries:
+      - reference-id: CCC.Core.TH01
+        strength: 0 # Not yet specified
+        remarks: Access control is misconfigured
+      - reference-id: CCC.Core.TH02
+        strength: 0 # Not yet specified
+        remarks: Data is intercepted in transit
+      - reference-id: CCC.Core.TH03
+        strength: 0 # Not yet specified
+        remarks: Deployment region network is untrusted
+      - reference-id: CCC.Core.TH04
+        strength: 0 # Not yet specified
+        remarks: Data is replicated to untrusted or external locations
+      - reference-id: CCC.Core.TH05
+        strength: 0 # Not yet specified
+        remarks: Data is corrupted during replication
+      - reference-id: CCC.Core.TH06
+        strength: 0 # Not yet specified
+        remarks: Data is lost or corrupted
+      - reference-id: CCC.Core.TH07
+        strength: 0 # Not yet specified
+        remarks: Logs are Tampered With or Deleted
+      - reference-id: CCC.Core.TH08
+        strength: 0 # Not yet specified
+        remarks: Cost Management Data is Manipulated
+      - reference-id: CCC.Core.TH09
+        strength: 0 # Not yet specified
+        remarks: Logs or Monitoring Data are Read by Unauthorized Users
+      - reference-id: CCC.Core.TH10
+        strength: 0 # Not yet specified
+        remarks: Alerts are Intercepted
+      - reference-id: CCC.Core.TH11
+        strength: 0 # Not yet specified
+        remarks: Event Notifications are Incorrectly Triggered
+      - reference-id: CCC.Core.TH12
+        strength: 0 # Not yet specified
+        remarks: Resource constraints are exhausted
+      - reference-id: CCC.Core.TH13
+        strength: 0 # Not yet specified
+        remarks: Resource Tags Are Manipulated
+      - reference-id: CCC.Core.TH14
+        strength: 0 # Not yet specified
+        remarks: Older Resource Versions Are Exploited
+      - reference-id: CCC.Core.TH15
+        strength: 0 # Not yet specified
+        remarks: Automated Enumeration and Reconnaissance by Non-Human Entities

--- a/catalogs/orchestration/k8s/controls.yaml
+++ b/catalogs/orchestration/k8s/controls.yaml
@@ -1,0 +1,21 @@
+imported-controls:
+  - reference-id: CCC
+    entries:
+      - reference-id: CCC.Core.CN01
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN02
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN03
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN04
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN05
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN06
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN07
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN09
+        strength: 0 # Not yet specified
+      - reference-id: CCC.Core.CN11
+        strength: 0 # Not yet specified

--- a/catalogs/orchestration/k8s/threats.yaml
+++ b/catalogs/orchestration/k8s/threats.yaml
@@ -1,0 +1,48 @@
+imported-threats:
+  - reference-id: CCC
+    entries:
+      - reference-id: CCC.Core.TH01
+        strength: 0 # Not yet specified
+        remarks: Access control is misconfigured
+      - reference-id: CCC.Core.TH02
+        strength: 0 # Not yet specified
+        remarks: Data is intercepted in transit
+      - reference-id: CCC.Core.TH03
+        strength: 0 # Not yet specified
+        remarks: Deployment region network is untrusted
+      - reference-id: CCC.Core.TH04
+        strength: 0 # Not yet specified
+        remarks: Data is replicated to untrusted or external locations
+      - reference-id: CCC.Core.TH05
+        strength: 0 # Not yet specified
+        remarks: Data is corrupted during replication
+      - reference-id: CCC.Core.TH06
+        strength: 0 # Not yet specified
+        remarks: Data is lost or corrupted
+      - reference-id: CCC.Core.TH07
+        strength: 0 # Not yet specified
+        remarks: Logs are Tampered With or Deleted
+      - reference-id: CCC.Core.TH08
+        strength: 0 # Not yet specified
+        remarks: Cost Management Data is Manipulated
+      - reference-id: CCC.Core.TH09
+        strength: 0 # Not yet specified
+        remarks: Logs or Monitoring Data are Read by Unauthorized Users
+      - reference-id: CCC.Core.TH10
+        strength: 0 # Not yet specified
+        remarks: Alerts are Intercepted
+      - reference-id: CCC.Core.TH11
+        strength: 0 # Not yet specified
+        remarks: Event Notifications are Incorrectly Triggered
+      - reference-id: CCC.Core.TH12
+        strength: 0 # Not yet specified
+        remarks: Resource constraints are exhausted
+      - reference-id: CCC.Core.TH13
+        strength: 0 # Not yet specified
+        remarks: Resource Tags Are Manipulated
+      - reference-id: CCC.Core.TH14
+        strength: 0 # Not yet specified
+        remarks: Older Resource Versions Are Exploited
+      - reference-id: CCC.Core.TH15
+        strength: 0 # Not yet specified
+        remarks: Automated Enumeration and Reconnaissance by Non-Human Entities


### PR DESCRIPTION
## Summary

Three build targets — `catalogs/management/tracing/`, `catalogs/orchestration/etl/`, `catalogs/orchestration/k8s/` — ship a `metadata.yaml` and `capabilities.yaml` but are missing `controls.yaml` and `threats.yaml` entirely. This PR adds CCC.Core-import stubs to all three so the directory layout matches every other catalog and the targets are picked up by future tooling.

- Each new `threats.yaml` imports `CCC.Core.TH01`–`TH15` (same baseline used by `catalogs/compute/serverless-computing/threats.yaml`).
- Each new `controls.yaml` imports the same CCC.Core controls baseline used by `catalogs/compute/virtual-machines/controls.yaml`.

The stubs are imports-only. They will not compile through `delivery-toolkit compile` until #(follow-up PR) lands the "imports-only is OK" fix — the compile tool currently errors with `no native … to compile`. That's a known limitation that already affects 7 other source files; this PR just brings the missing targets up to the same baseline.

## Dependencies

This PR is independent of #1067 and the upcoming compile-tool fix. Once the compile-tool fix lands, every catalog in the repo will compile cleanly.

## Test plan

- [ ] CI YAML schema check passes for the new stub files
- [ ] CI lint check passes
- [ ] After the compile-tool fix lands, these targets produce a valid `ControlCatalog` and `ThreatCatalog` artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)