### PR TITLE
fix: Add missing catalogs to the sidebar

### DIFF
--- a/website/src/components/Catalogs/CatalogCategoryPage.tsx
+++ b/website/src/components/Catalogs/CatalogCategoryPage.tsx
@@ -122,7 +122,7 @@ export const CatalogCategoryPage: React.FC<Props> = ({ data, service }) => {
 
   useEffect(() => {
     fetch(`/content/${category}.md`)
-      .then((r) => (r.ok ? r.text() : ""))
+      .then((r) => (r.ok && r.headers.get("content-type")?.includes("text/plain") ? r.text() : ""))
       .then((md) => setDescBody(md.replace(/^---[\s\S]*?---\n?/, "")));
   }, [category]);
 

--- a/website/src/components/Catalogs/CatalogSidebar.tsx
+++ b/website/src/components/Catalogs/CatalogSidebar.tsx
@@ -18,8 +18,9 @@ interface Category {
 
 export const CATALOG_STRUCTURE: Category[] = [
   { slug: "ai-ml",      label: "AI/ML",       services: [
-    { slug: "gen-ai", label: "Gen AI" },
-    { slug: "mlde",   label: "MLDE" },
+    { slug: "gen-ai",              label: "Gen AI" },
+    { slug: "mlde",                label: "MLDE" },
+    { slug: "multi-agent-refarch", label: "Multi-Agent Ref Arch" },
   ]},
   { slug: "compute",    label: "Compute",     services: [
     { slug: "batchproc",             label: "Batch Processing" },
@@ -51,9 +52,16 @@ export const CATALOG_STRUCTURE: Category[] = [
     { slug: "monitoring",label: "Monitoring" },
     { slug: "tracing",   label: "Tracing" },
   ]},
+  { slug: "app-integration", label: "App Integration", services: [
+    { slug: "message", label: "Messaging" },
+  ]},
   { slug: "networking", label: "Networking",  services: [
     { slug: "loadbalancer", label: "Load Balancer" },
     { slug: "vpc",          label: "VPC" },
+  ]},
+  { slug: "orchestration", label: "Orchestration", services: [
+    { slug: "etl", label: "ETL" },
+    { slug: "k8s", label: "Kubernetes" },
   ]},
   { slug: "storage",    label: "Storage",     services: [
     { slug: "object", label: "Object" },

--- a/website/src/components/Catalogs/CatalogTypeOverviewPage.tsx
+++ b/website/src/components/Catalogs/CatalogTypeOverviewPage.tsx
@@ -31,7 +31,7 @@ export const CatalogTypeOverviewPage: React.FC<Props> = ({ data }) => {
 
   useEffect(() => {
     fetch(`/content/${type}.md`)
-      .then((r) => (r.ok ? r.text() : ""))
+      .then((r) => (r.ok && r.headers.get("content-type")?.includes("text/plain") ? r.text() : ""))
       .then((md) => setBody(md.replace(/^---[\s\S]*?---\n?/, "")));
   }, [type]);
 


### PR DESCRIPTION
## Summary

Add missing catalogs to the sidebar and filter out buggy responses with code 200 missing static files serving HMTL as text.

## Related issues

https://github.com/finos/common-cloud-controls/issues/1136

## Checklist

- [ ] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [ ] Tests / docs updated as needed
