### PR TITLE
feat: generate sidebar menu titles from file system structure of catalogs

### DIFF
--- a/website/src/components/Catalogs/CatalogCategoryPage.tsx
+++ b/website/src/components/Catalogs/CatalogCategoryPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import Link from "@docusaurus/Link";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { CatalogSidebar, CATALOG_STRUCTURE } from "./CatalogSidebar";
+import { CatalogSidebar } from "./CatalogSidebar";
 import { markdownComponents } from "./markdownComponents";
 import { prettifySegment } from "@site/src/content/catalogUtils";
 import { User } from "../shared/User";
@@ -47,12 +47,11 @@ const TYPE_LABELS: Record<string, string> = {
 };
 
 function getCategoryLabel(category: string): string {
-  return CATALOG_STRUCTURE.find((c) => c.slug === category)?.label ?? prettifySegment(category);
+  return prettifySegment(category);
 }
 
-function getServiceLabel(category: string, service: string): string {
-  const cat = CATALOG_STRUCTURE.find((c) => c.slug === category);
-  return cat?.services.find((s) => s.slug === service)?.label ?? prettifySegment(service);
+function getServiceLabel(_category: string, service: string): string {
+  return prettifySegment(service);
 }
 
 function TypeButtons({ svcInfo }: { svcInfo: CatalogServiceInfo }) {

--- a/website/src/components/Catalogs/CatalogCategoryPage.tsx
+++ b/website/src/components/Catalogs/CatalogCategoryPage.tsx
@@ -4,7 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CatalogSidebar } from "./CatalogSidebar";
 import { markdownComponents } from "./markdownComponents";
-import { prettifySegment } from "@site/src/content/catalogUtils";
+import { prettifySegment, labelFromTitle } from "@site/src/content/catalogUtils";
 import { User } from "../shared/User";
 
 export interface CatalogContributor {
@@ -25,6 +25,7 @@ export interface CatalogReleaseSummary {
 
 export interface CatalogServiceInfo {
   slug: string;
+  title?: string;
   types: Array<{ type: string; typePath: string }>;
   releases: CatalogReleaseSummary[];
 }
@@ -50,8 +51,8 @@ function getCategoryLabel(category: string): string {
   return prettifySegment(category);
 }
 
-function getServiceLabel(_category: string, service: string): string {
-  return prettifySegment(service);
+function getServiceLabel(_category: string, service: string, title?: string): string {
+  return title ? labelFromTitle(title) : prettifySegment(service);
 }
 
 function TypeButtons({ svcInfo }: { svcInfo: CatalogServiceInfo }) {
@@ -136,7 +137,7 @@ export const CatalogCategoryPage: React.FC<Props> = ({ data, service }) => {
             {getCategoryLabel(category)}
           </p>
           <h1 style={{ fontSize: "2.5rem", fontWeight: 700, marginBottom: "1.5rem", marginTop: 0, color: "var(--gf-color-accent)", lineHeight: 1.2 }}>
-            {getServiceLabel(category, service)}
+            {getServiceLabel(category, service, svcInfo?.title)}
           </h1>
           {svcInfo ? (
             <>
@@ -187,7 +188,7 @@ export const CatalogCategoryPage: React.FC<Props> = ({ data, service }) => {
           services.map((svc) => (
             <div key={svc.slug} style={{ marginBottom: "var(--gf-space-xl)" }}>
               <h2 style={{ fontSize: "1.5rem", fontWeight: 700, marginBottom: "1rem", lineHeight: 1.3 }}>
-                {getServiceLabel(category, svc.slug)}
+                {getServiceLabel(category, svc.slug, svc.title)}
               </h2>
               <TypeButtons svcInfo={svc} />
             </div>

--- a/website/src/components/Catalogs/CatalogSidebar.tsx
+++ b/website/src/components/Catalogs/CatalogSidebar.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Link from "@docusaurus/Link";
 import { useLocation } from "@docusaurus/router";
 import { usePluginData } from "@docusaurus/useGlobalData";
-import { prettifySegment } from "@site/src/content/catalogUtils";
+import { prettifySegment, labelFromTitle } from "@site/src/content/catalogUtils";
 import type { CatalogTypeIndexData } from "./CatalogTypeOverviewPage";
 import "./CatalogSidebar.css";
 
@@ -20,7 +20,7 @@ interface Category {
 
 interface RawStructureEntry {
   slug: string;
-  services: string[];
+  services: Array<{ slug: string; title: string }>;
 }
 
 const HREF_OVERRIDES: Record<string, string> = {
@@ -31,9 +31,9 @@ function buildCatalogStructure(raw: RawStructureEntry[]): Category[] {
   return raw.map(({ slug, services }) => ({
     slug,
     label: prettifySegment(slug),
-    services: services.map((svc) => ({
+    services: services.map(({ slug: svc, title }) => ({
       slug: svc,
-      label: prettifySegment(svc),
+      label: labelFromTitle(title),
       href: HREF_OVERRIDES[`${slug}/${svc}`],
     })),
   }));

--- a/website/src/components/Catalogs/CatalogSidebar.tsx
+++ b/website/src/components/Catalogs/CatalogSidebar.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import Link from "@docusaurus/Link";
 import { useLocation } from "@docusaurus/router";
+import { usePluginData } from "@docusaurus/useGlobalData";
+import { prettifySegment } from "@site/src/content/catalogUtils";
 import type { CatalogTypeIndexData } from "./CatalogTypeOverviewPage";
 import "./CatalogSidebar.css";
 
 interface Service {
   slug: string;
   label: string;
-  href?: string; // optional override for the generated /catalogs/<cat>/<svc> path
+  href?: string;
 }
 
 interface Category {
@@ -16,49 +18,26 @@ interface Category {
   services: Service[];
 }
 
-export const CATALOG_STRUCTURE: Category[] = [
-  { slug: "ai-ml",      label: "AI/ML",       services: [
-    { slug: "gen-ai", label: "Gen AI" },
-    { slug: "mlde",   label: "MLDE" },
-  ]},
-  { slug: "compute",    label: "Compute",     services: [
-    { slug: "batchproc",             label: "Batch Processing" },
-    { slug: "serverless-computing",  label: "Serverless Computing" },
-    { slug: "virtual-machines",      label: "Virtual Machines" },
-  ]},
-  { slug: "core",       label: "Core",        services: [
-    { slug: "ccc", label: "CCC", href: "/catalogs/core" },
-  ]},
-  { slug: "crypto",     label: "Crypto",      services: [
-    { slug: "key",     label: "Key" },
-    { slug: "secrets", label: "Secrets" },
-  ]},
-  { slug: "database",   label: "Database",    services: [
-    { slug: "relational", label: "Relational" },
-    { slug: "vector",     label: "Vector" },
-    { slug: "warehouse",  label: "Warehouse" },
-  ]},
-  { slug: "devtools",   label: "DevTools",    services: [
-    { slug: "build",              label: "Build" },
-    { slug: "container-registry", label: "Container Registry" },
-  ]},
-  { slug: "identity",   label: "Identity",    services: [
-    { slug: "iam", label: "IAM" },
-  ]},
-  { slug: "management", label: "Management",  services: [
-    { slug: "auditlog",  label: "Audit Log" },
-    { slug: "logging",   label: "Logging" },
-    { slug: "monitoring",label: "Monitoring" },
-    { slug: "tracing",   label: "Tracing" },
-  ]},
-  { slug: "networking", label: "Networking",  services: [
-    { slug: "loadbalancer", label: "Load Balancer" },
-    { slug: "vpc",          label: "VPC" },
-  ]},
-  { slug: "storage",    label: "Storage",     services: [
-    { slug: "object", label: "Object" },
-  ]},
-];
+interface RawStructureEntry {
+  slug: string;
+  services: string[];
+}
+
+const HREF_OVERRIDES: Record<string, string> = {
+  "core/ccc": "/catalogs/core",
+};
+
+function buildCatalogStructure(raw: RawStructureEntry[]): Category[] {
+  return raw.map(({ slug, services }) => ({
+    slug,
+    label: prettifySegment(slug),
+    services: services.map((svc) => ({
+      slug: svc,
+      label: prettifySegment(svc),
+      href: HREF_OVERRIDES[`${slug}/${svc}`],
+    })),
+  }));
+}
 
 const TYPE_TITLE: Record<string, string> = {
   capabilities: "Capabilities",
@@ -67,12 +46,13 @@ const TYPE_TITLE: Record<string, string> = {
 };
 
 interface CatalogSidebarProps {
-  // When provided, filter to only these services and show a type heading
   typeIndexData?: CatalogTypeIndexData;
 }
 
 export const CatalogSidebar: React.FC<CatalogSidebarProps> = ({ typeIndexData }) => {
   const { pathname } = useLocation();
+  const pluginData = usePluginData("catalog-routes") as { catalogStructure?: RawStructureEntry[] } | undefined;
+  const catalogStructure = buildCatalogStructure(pluginData?.catalogStructure ?? []);
 
   const typeLinkMap = typeIndexData
     ? new Map(typeIndexData.serviceEntries.map((e) => [`${e.category}/${e.service}`, e.typePath]))
@@ -88,8 +68,7 @@ export const CatalogSidebar: React.FC<CatalogSidebarProps> = ({ typeIndexData })
   return (
     <nav className="catalog-sidebar">
       {title && <div className="catalog-sidebar-type-title">{title}</div>}
-      {CATALOG_STRUCTURE.map(({ slug, label, services }) => {
-        // When filtering, only show services that have the type
+      {catalogStructure.map(({ slug, label, services }) => {
         const visibleServices = typeLinkMap
           ? services.filter((svc) => typeLinkMap.has(`${slug}/${svc.slug}`))
           : services;

--- a/website/src/content/catalogUtils.ts
+++ b/website/src/content/catalogUtils.ts
@@ -1,7 +1,17 @@
 import { SectionItem } from "./sections";
 
 // Prettify a slug segment or compound slug (e.g. "ai-ml" → "AI/ML", "gen-ai" → "Gen AI").
+const SLUG_DISPLAY_NAMES: Record<string, string> = {
+  mlde: "MLDE",
+  ccc: "CCC",
+  devtools: "DevTools",
+  batchproc: "Batch Processing",
+  auditlog: "Audit Log",
+  loadbalancer: "Load Balancer",
+};
+
 export function prettifySegment(s: string): string {
+  if (SLUG_DISPLAY_NAMES[s]) return SLUG_DISPLAY_NAMES[s];
   const acronyms = new Set(["ai", "ml", "iam", "vpc", "etl", "k8s", "sdk"]);
   const parts = s.split("-");
   if (parts.every((p) => acronyms.has(p))) {

--- a/website/src/content/catalogUtils.ts
+++ b/website/src/content/catalogUtils.ts
@@ -1,17 +1,17 @@
 import { SectionItem } from "./sections";
 
-// Prettify a slug segment or compound slug (e.g. "ai-ml" → "AI/ML", "gen-ai" → "Gen AI").
-const SLUG_DISPLAY_NAMES: Record<string, string> = {
-  mlde: "MLDE",
-  ccc: "CCC",
-  devtools: "DevTools",
-  batchproc: "Batch Processing",
-  auditlog: "Audit Log",
-  loadbalancer: "Load Balancer",
-};
+// Strip common title prefixes so "CCC Batch Processing" → "Batch Processing".
+const TITLE_PREFIXES = ['FINOS CCC ', 'Common Cloud Controls ', 'CCC '];
 
+export function labelFromTitle(title: string): string {
+  for (const prefix of TITLE_PREFIXES) {
+    if (title.startsWith(prefix)) return title.slice(prefix.length);
+  }
+  return title;
+}
+
+// Prettify a slug segment or compound slug (e.g. "ai-ml" → "AI/ML", "gen-ai" → "Gen AI").
 export function prettifySegment(s: string): string {
-  if (SLUG_DISPLAY_NAMES[s]) return SLUG_DISPLAY_NAMES[s];
   const acronyms = new Set(["ai", "ml", "iam", "vpc", "etl", "k8s", "sdk"]);
   const parts = s.split("-");
   if (parts.every((p) => acronyms.has(p))) {

--- a/website/src/plugin/catalog-routes/index.ts
+++ b/website/src/plugin/catalog-routes/index.ts
@@ -690,6 +690,14 @@ export default function pluginCatalogRoutes(context: LoadContext): Plugin<Plugin
         });
       }
 
+      const catalogStructure = Array.from(categories.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([catSlug, catData]) => ({
+          slug: catSlug,
+          services: catData.services.map((svc) => svc.slug),
+        }));
+      setGlobalData({ catalogStructure });
+
       console.log(`catalog-routes: registered ${added.size} routes`);
     },
   };

--- a/website/src/plugin/catalog-routes/index.ts
+++ b/website/src/plugin/catalog-routes/index.ts
@@ -67,8 +67,14 @@ export interface CatalogAssessmentRequirementRef {
   url: string;
 }
 
+export interface CatalogStructureEntry {
+  slug: string;
+  services: Array<{ slug: string; title: string }>;
+}
+
 export interface CatalogGlobalData {
   assessmentRequirements: CatalogAssessmentRequirementRef[];
+  catalogStructure: CatalogStructureEntry[];
 }
 
 export interface CatalogVersionData {
@@ -106,6 +112,7 @@ export interface CatalogReleaseSummary {
 
 export interface CatalogServiceInfo {
   slug: string;
+  title: string;
   types: Array<{ type: string; typePath: string }>;
   releases: CatalogReleaseSummary[];
 }
@@ -282,8 +289,9 @@ export default function pluginCatalogRoutes(context: LoadContext): Plugin<Plugin
       const catalogsDir = path.resolve(context.siteDir, '../catalogs');
       const releasesDir = path.join(context.siteDir, 'src/data/ccc-releases');
 
-      // Build metadataId → { category, service } from source catalog metadata.yaml files
+      // Build metadataId → { category, service } and cat/svc → title from source catalog metadata.yaml files
       const idToPath = new Map<string, { category: string; service: string }>();
+      const svcTitles = new Map<string, string>();
       if (fs.existsSync(catalogsDir)) {
         for (const cat of fs.readdirSync(catalogsDir)) {
           const catDir = path.join(catalogsDir, cat);
@@ -295,7 +303,11 @@ export default function pluginCatalogRoutes(context: LoadContext): Plugin<Plugin
             if (!fs.existsSync(metaFile)) continue;
             const meta = yaml.load(fs.readFileSync(metaFile, 'utf8')) as Record<string, any>;
             const id = meta?.metadata?.id as string | undefined;
-            if (id) idToPath.set(id, { category: cat, service: svc });
+            const title = cleanStr(meta?.metadata?.title ?? '');
+            if (id) {
+              idToPath.set(id, { category: cat, service: svc });
+              if (title) svcTitles.set(`${cat}/${svc}`, title);
+            }
           }
         }
       }
@@ -564,6 +576,7 @@ export default function pluginCatalogRoutes(context: LoadContext): Plugin<Plugin
               .sort((a, b) => compareVersionTags(a.version, b.version));
             return {
               slug,
+              title: svcTitles.get(`${cat}/${slug}`) ?? slug,
               types: TYPE_ORDER
                 .filter(t => typeSet.has(t))
                 .map(type => ({ type, typePath: `/catalogs/${cat}/${slug}/${type}` })),
@@ -595,7 +608,13 @@ export default function pluginCatalogRoutes(context: LoadContext): Plugin<Plugin
           });
         }
       }
-      setGlobalData({ assessmentRequirements } satisfies CatalogGlobalData);
+      const catalogStructure: CatalogStructureEntry[] = Array.from(categories.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([catSlug, catData]) => ({
+          slug: catSlug,
+          services: catData.services.map((svc) => ({ slug: svc.slug, title: svc.title })),
+        }));
+      setGlobalData({ assessmentRequirements, catalogStructure } satisfies CatalogGlobalData);
 
       const add = (routePath: string, modules?: Record<string, string>) => {
         if (added.has(routePath)) return;
@@ -689,14 +708,6 @@ export default function pluginCatalogRoutes(context: LoadContext): Plugin<Plugin
           modules: { catalogTypeIndexData: typeIndexFiles.get(typeName)! },
         });
       }
-
-      const catalogStructure = Array.from(categories.entries())
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([catSlug, catData]) => ({
-          slug: catSlug,
-          services: catData.services.map((svc) => svc.slug),
-        }));
-      setGlobalData({ catalogStructure });
 
       console.log(`catalog-routes: registered ${added.size} routes`);
     },


### PR DESCRIPTION

## Summary

sidebar menu is now generated by exploring the catalog filesystem for names, this adds in orchestration and app integration to the menu

## Related issues
closes #1136 

