### PR TITLE
feat: Homepage/ Mobile adjustements

### DIFF
--- a/website/src/components/Breadcrumb/index.tsx
+++ b/website/src/components/Breadcrumb/index.tsx
@@ -33,7 +33,7 @@ const Breadcrumb = () => {
   const pathParts = location.pathname.split("/").filter(Boolean);
 
   return (
-    <nav className="text-sm text-gray-500 mb-4 mx-32 py-5">
+    <nav className="text-sm text-gray-500 mb-4 mx-16 py-5">
       <Link to="/" className="px-3 hover:bg-gray-200 rounded-full hover:no-underline">
         Home
       </Link>

--- a/website/src/components/Catalogs/CatalogSidebar.css
+++ b/website/src/components/Catalogs/CatalogSidebar.css
@@ -12,6 +12,12 @@
   border-radius: 8px;
 }
 
+@media screen and (max-width: 600px) {
+  .catalog-sidebar{
+      position: static;
+  }
+}
+
 .catalog-sidebar-type-title {
   font-size: 0.7rem;
   font-weight: 700;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -205,6 +205,12 @@ html[data-theme="dark"] .dropdown__link--active {
   padding: 2rem 1.5rem;
   align-items: flex-start;
 }
+/* Catalog page layout on mobile: sidebar on top, main content below */
+@media screen and (max-width: 600px) {
+  .page-layout {
+      display: grid;
+  }
+}
 
 /* Catalog type buttons (Capabilities / Threats / Controls) */
 .catalog-type-btn {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -48,8 +48,8 @@ export default function Home(): ReactNode {
         </div>
         <TheStory />
         <LevelUp />
-        <JoinCommunity />
         <SteeringCommittee />
+        <JoinCommunity />
       </main>
     </Layout>
   );


### PR DESCRIPTION
## Summary
-Reduced breadcrumb margins for better formatting on mobile
-Swapped "Join" and "Steering Comittee" sections of Home page for better flow
-Adjusted catalog pages so that the sidebar sits on top in mobile views

## Related issues
#1145
#1152
## Checklist

- [x] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [x] Tests / docs updated as needed
