### PR TITLE
fix: Fixing the terraform links

### DIFF
--- a/cfi-testing/actions-config/aws-secrets-finos.yaml
+++ b/cfi-testing/actions-config/aws-secrets-finos.yaml
@@ -7,7 +7,7 @@ cfi:
   name: CCC AWS Secret Management Fixture
   description: >-
     Runs behavioural checks for CCC.SecMgmt against the AWS Secrets Manager fixture.
-  path: https://github.com/finos/common-cloud-controls/tree/main/modules/cloud-api-test/terraform/aws
+  path: modules/cloud-api-test/terraform/aws
   test-on-branches:
     - main
   git: https://github.com/finos/common-cloud-controls

--- a/cfi-testing/actions-config/aws-vpc-bad-finos.yaml
+++ b/cfi-testing/actions-config/aws-vpc-bad-finos.yaml
@@ -7,7 +7,7 @@ cfi:
   name: CCC AWS VPC Bad Fixture
   description: >-
     Runs behavioural checks against the intentionally non-compliant AWS VPC fixture.
-  path: https://github.com/finos/common-cloud-controls/tree/main/modules/integration-terraform/aws
+  path: modules/integration-terraform/aws
   test-on-branches:
     - main
   git: https://github.com/finos/common-cloud-controls

--- a/cfi-testing/actions-config/aws-vpc-good-finos.yaml
+++ b/cfi-testing/actions-config/aws-vpc-good-finos.yaml
@@ -7,7 +7,7 @@ cfi:
   name: CCC AWS VPC Good Fixture
   description: >-
     Runs behavioural checks against the compliant AWS VPC fixture.
-  path: https://github.com/finos/common-cloud-controls/tree/main/modules/integration-terraform/aws
+  path: modules/integration-terraform/aws
   test-on-branches:
     - main
   git: https://github.com/finos/common-cloud-controls

--- a/cfi-testing/actions-config/azure-avm-secrets-finos.yaml
+++ b/cfi-testing/actions-config/azure-avm-secrets-finos.yaml
@@ -8,7 +8,7 @@ cfi:
   description: >-
     Control-informed AVM key vault deployment from ccc-cfi-compliance
     remote/azure/avm (Azure/avm-res-keyvault-vault @ 0.10.2).
-  path: https://github.com/finos-labs/ccc-cfi-compliance/tree/main/remote/azure/avm
+  path: remote/azure/avm
   test-on-branches:
     - main
   git: https://github.com/Azure/terraform-azurerm-avm-res-keyvault-vault

--- a/cfi-testing/actions-config/azure-avm-serverless-finos.yaml
+++ b/cfi-testing/actions-config/azure-avm-serverless-finos.yaml
@@ -8,7 +8,7 @@ cfi:
   description: >-
     Control-informed AVM Flex Consumption function app deployment from
     ccc-cfi-compliance remote/azure/avm (Azure/avm-res-web-site @ 0.22.0).
-  path: https://github.com/finos-labs/ccc-cfi-compliance/tree/main/remote/azure/avm
+  path: remote/azure/avm
   test-on-branches:
     - main
   git: https://github.com/Azure/terraform-azurerm-avm-res-web-site

--- a/cfi-testing/actions-config/azure-avm-storage-finos.yaml
+++ b/cfi-testing/actions-config/azure-avm-storage-finos.yaml
@@ -8,7 +8,7 @@ cfi:
   description: >-
     Control-informed AVM storage account deployment from ccc-cfi-compliance
     remote/azure/avm (Azure/avm-res-storage-storageaccount @ 0.7.2).
-  path: https://github.com/finos-labs/ccc-cfi-compliance/tree/main/remote/azure/avm
+  path: remote/azure/avm
   test-on-branches:
     - main
   git: https://github.com/Azure/terraform-azurerm-avm-res-storage-storageaccount

--- a/cfi-testing/actions-config/azure-avm-virtual-machines-finos.yaml
+++ b/cfi-testing/actions-config/azure-avm-virtual-machines-finos.yaml
@@ -8,7 +8,7 @@ cfi:
   description: >-
     Control-informed AVM virtual machine deployment from ccc-cfi-compliance
     remote/azure/avm (Azure/avm-res-compute-virtualmachine @ 0.21.0).
-  path: https://github.com/finos-labs/ccc-cfi-compliance/tree/main/remote/azure/avm
+  path: remote/azure/avm
   test-on-branches:
     - main
   git: https://github.com/Azure/terraform-azurerm-avm-res-compute-virtualmachine

--- a/cfi-testing/actions-config/azure-secrets-finos.yaml
+++ b/cfi-testing/actions-config/azure-secrets-finos.yaml
@@ -7,7 +7,7 @@ cfi:
   name: CCC Azure Secret Management Fixture
   description: >-
     Runs behavioural checks for CCC.SecMgmt against the Azure Key Vault fixture.
-  path: https://github.com/finos/common-cloud-controls/tree/main/modules/cloud-api-test/terraform/azure
+  path: modules/cloud-api-test/terraform/azure
   test-on-branches:
     - main
   git: https://github.com/finos/common-cloud-controls

--- a/cfi-testing/actions-config/azure-storage-finos.yaml
+++ b/cfi-testing/actions-config/azure-storage-finos.yaml
@@ -8,7 +8,7 @@ cfi:
   description: >-
     This module creates a secure Azure Storage Account with encryption, networking,
     monitoring, and advanced security features.
-  path: https://github.com/finos-labs/ccc-cfi-compliance/tree/main/remote/azure/storageaccount
+  path: remote/azure/storageaccount
   test-on-branches:
     - main
   git: https://github.com/Azure/terraform-azurerm-avm-res-storage-storageaccount

--- a/cfi-testing/actions-config/gcp-secrets-finos.yaml
+++ b/cfi-testing/actions-config/gcp-secrets-finos.yaml
@@ -7,7 +7,7 @@ cfi:
   name: CCC GCP Secret Management Fixture
   description: >-
     Runs behavioural checks for CCC.SecMgmt against the GCP Secret Manager fixture.
-  path: https://github.com/finos/common-cloud-controls/tree/main/modules/cloud-api-test/terraform/gcp
+  path: modules/cloud-api-test/terraform/gcp
   test-on-branches:
     - main
   git: https://github.com/finos/common-cloud-controls

--- a/cfi-testing/actions-config/gcp-serverless-finos.yaml
+++ b/cfi-testing/actions-config/gcp-serverless-finos.yaml
@@ -7,7 +7,7 @@ cfi:
   name: CCC GCP Serverless Computing Fixture
   description: >-
     Runs behavioural checks against the GCP serverless-computing fixture.
-  path: https://github.com/finos/common-cloud-controls/tree/main/modules/integration-terraform/gcp
+  path: modules/integration-terraform/gcp
   test-on-branches:
     - main
   git: https://github.com/finos/common-cloud-controls

--- a/cfi-testing/actions-config/gcp-virtual-machines-finos.yaml
+++ b/cfi-testing/actions-config/gcp-virtual-machines-finos.yaml
@@ -7,7 +7,7 @@ cfi:
   name: CCC GCP Virtual Machines Fixture
   description: >-
     Runs behavioural checks for CCC.VM against the GCP virtual machines fixture.
-  path: https://github.com/finos/common-cloud-controls/tree/main/modules/integration-terraform/gcp
+  path: modules/integration-terraform/gcp
   test-on-branches:
     - main
   git: https://github.com/finos/common-cloud-controls


### PR DESCRIPTION
## Summary
-cfi-testing config files had the entire git link in the "path" property, which the code appends to a separate git link to generate the terraform link. These path properties have been edited to work with the code.

## Related issues
#1151 

## Checklist

- [ ] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [ ] Tests / docs updated as needed
