### PR TITLE
fix: Retry link checker as it fails a lot

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,11 +10,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@v1
+      - name: Install lychee
+        uses: taiki-e/install-action@v2
         with:
-          args: --base . --verbose --accept 429 --no-progress './**/*.md'
-          output: lychee/results.md
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fail: true
+          tool: lychee
+
+      # External sites are flaky; retry the full run before failing the check.
+      - name: Link Checker
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 45
+          command: |
+            mkdir -p lychee
+            lychee --base . --verbose --accept 429 --max-retries 5 --retry-wait-time 2 --no-progress './**/*.md' --output lychee/results.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -17,7 +17,7 @@ jobs:
 
       # External sites are flaky; retry the full run before failing the check.
       - name: Link Checker
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 15
           max_attempts: 3

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -15,15 +15,17 @@ jobs:
         with:
           tool: lychee
 
-      # External sites are flaky; retry the full run before failing the check.
       - name: Link Checker
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_wait_seconds: 45
-          command: |
-            mkdir -p lychee
-            lychee --root-dir "${GITHUB_WORKSPACE}" --verbose --accept 429 --max-retries 5 --retry-wait-time 2 --no-progress './**/*.md' --output lychee/results.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p lychee
+          lychee \
+            --root-dir "${GITHUB_WORKSPACE}" \
+            --verbose \
+            --no-progress \
+            --max-retries 5 \
+            --retry-wait-time 2 \
+            --accept '200..=299,429' \
+            --output lychee/results.md \
+            './**/*.md'

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,6 +24,6 @@ jobs:
           retry_wait_seconds: 45
           command: |
             mkdir -p lychee
-            lychee --base . --verbose --accept 429 --max-retries 5 --retry-wait-time 2 --no-progress './**/*.md' --output lychee/results.md
+            lychee --root-dir "${GITHUB_WORKSPACE}" --verbose --accept 429 --max-retries 5 --retry-wait-time 2 --no-progress './**/*.md' --output lychee/results.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

As mentioned in the title, we're seeing the link checker failing for a whole bunch of PRs.  
This should retry the link checking to reduce failures.
