### PR TITLE
feat(mapping): ATR cross-reference for CCC GenAI threats

### DIFF
--- a/catalogs/ai-ml/gen-ai/mappings/threats-agent-threat-rules.yaml
+++ b/catalogs/ai-ml/gen-ai/mappings/threats-agent-threat-rules.yaml
@@ -1,0 +1,112 @@
+title: CCC Generative AI Platform Threats to Agent Threat Rules
+metadata:
+  id: CCC.GenAI.TH.threats-to-agent-threat-rules
+  type: MappingDocument
+  gemara-version: 1.2.0
+  version: dev
+  description: Maps CCC Generative AI Platform threats to Agent Threat Rules detection rules that relate
+    to them.
+  author:
+    id: FINOS-CCC
+    name: FINOS Common Cloud Controls
+    type: Human
+  mapping-references:
+  - id: CCC.GenAI.TH
+    title: CCC Generative AI Platform Threats
+    version: dev
+  - id: AGENT-THREAT-RULES
+    title: Agent Threat Rules
+    version: dev_to-be-determined
+    description: Open catalog of executable detection rules for AI agent threats.
+    url: https://agentthreatrule.org
+source-reference:
+  reference-id: CCC.GenAI.TH
+  entry-type: Threat
+target-reference:
+  reference-id: AGENT-THREAT-RULES
+  entry-type: Control
+mappings:
+- id: CCC.GenAI.TH01-agent-threat-rules
+  source: CCC.GenAI.TH01
+  relationship: relates-to
+  targets:
+  - entry-id: ATR-2026-00001
+    remarks: Direct prompt injection via user input — the direct-injection path.
+  - entry-id: ATR-2026-00002
+    remarks: Indirect prompt injection via external/ingested content — the indirect path.
+  - entry-id: ATR-2026-00003
+    remarks: Jailbreak / system-prompt-override attempts at the input layer.
+- id: CCC.GenAI.TH02-agent-threat-rules
+  source: CCC.GenAI.TH02
+  relationship: relates-to
+  targets:
+  - entry-id: ATR-2026-00070
+    remarks: Data poisoning via RAG and knowledge-base contamination.
+  - entry-id: ATR-2026-01774
+    remarks: RAG & memory poisoning — embedded directives, trigger tokens, false authority (semantic).
+  - entry-id: ATR-2026-00450
+    remarks: Spring AI PromptChatMemoryAdvisor memory poisoning (CVE-2026-41713).
+  - entry-id: ATR-2026-01155
+    remarks: Persistent memory-plant command — fact/code storage injection.
+- id: CCC.GenAI.TH03-agent-threat-rules
+  source: CCC.GenAI.TH03
+  relationship: relates-to
+  targets:
+  - entry-id: ATR-2026-00020
+    remarks: System-prompt / internal-instruction leakage in model output.
+  - entry-id: ATR-2026-00021
+    remarks: Credential, API-key and secret exposure in agent output.
+- id: CCC.GenAI.TH04-agent-threat-rules
+  source: CCC.GenAI.TH04
+  relationship: relates-to
+  targets:
+  - entry-id: ATR-2026-00132
+    remarks: Covert authority claim / scope escalation embedded in output.
+  - entry-id: ATR-2026-00021
+    remarks: Credential / secret disclosure in output — insecure-output sanitisation point.
+- id: CCC.GenAI.TH06-agent-threat-rules
+  source: CCC.GenAI.TH06
+  relationship: relates-to
+  targets:
+  - entry-id: ATR-2026-00050
+    remarks: Runaway agent loop — unbounded autonomous action.
+  - entry-id: ATR-2026-00098
+    remarks: Unauthorised financial action taken by an AI agent.
+  - entry-id: ATR-2026-00099
+    remarks: High-risk tool invocation without required human confirmation.
+  - entry-id: ATR-2026-00428
+    remarks: Natural-language instruction to run unauthorised shell execution.
+  - entry-id: ATR-2026-00032
+    remarks: Agent goal hijacking — redirected to attacker-controlled objectives.
+- id: CCC.GenAI.TH07-agent-threat-rules
+  source: CCC.GenAI.TH07
+  relationship: relates-to
+  targets:
+  - entry-id: ATR-2026-00060
+    remarks: MCP skill impersonation and supply-chain attack.
+  - entry-id: ATR-2026-00061
+    remarks: Skill description-behaviour mismatch (declared vs actual capability).
+  - entry-id: ATR-2026-00062
+    remarks: Hidden capability in an MCP skill / plugin.
+  - entry-id: ATR-2026-00064
+    remarks: Over-permissioned MCP skill / plugin.
+  - entry-id: ATR-2026-00012
+    remarks: Unauthorised tool / plugin call detection.
+  - entry-id: ATR-2026-00013
+    remarks: SSRF via agent tool / plugin calls.
+- id: CCC.GenAI.TH08-agent-threat-rules
+  source: CCC.GenAI.TH08
+  relationship: relates-to
+  targets:
+  - entry-id: ATR-2026-00073
+    remarks: Malicious fine-tuning data used to tamper with model behaviour.
+  - entry-id: ATR-2026-00433
+    remarks: ModelCache torch.load() deserialization RCE (CVE-2025-45146).
+  - entry-id: ATR-2026-00072
+    remarks: Model behaviour extraction / theft.
+remarks: Authored in the standalone mapping-document layout introduced by the external-mappings migration
+  (PR 1129); these entries were previously inline external-mappings on threats.yaml. The target entry-type
+  is Control because Agent Threat Rules entries are executable detective controls rather than descriptions
+  of adversary technique. The relationship is a conservative 'relates-to' because the schema has no
+  detects/detected-by value. The target version is left unpinned because the rule catalog releases
+  continuously.


### PR DESCRIPTION
Adds a standalone mapping document relating CCC GenAI platform threats to Agent Threat Rules (ATR) detection rules, in the layout #1129 introduced.

Rebuilt as a single commit on current `main`. The branch previously carried four commits, the first of which added inline `external-mappings` to `threats.yaml` — the field #1129 removed — so replaying it conflicted even though the merge result did not. The net change is unchanged: one new file, +112 lines, nothing else touched.

## What this adds

`catalogs/ai-ml/gen-ai/mappings/threats-agent-threat-rules.yaml` — 25 references across seven threats, drawn from 24 distinct ATR rules:

| Threat | Refs |
|---|---|
| TH01 Prompt Injection | 3 |
| TH02 Data Poisoning | 4 |
| TH03 Sensitive Information Disclosure | 2 |
| TH04 Insecure / Unreliable Model Output | 2 |
| TH06 Unintended Action by a Model-Based Agent | 5 |
| TH07 Insecure Plugin | 6 |
| TH08 Model Tampering | 3 |

TH05 (Model Overreliance), TH09 (Lack of Explainability) and TH10 (Model Version Drift) are deliberately unmapped. ATR is runtime attack detection and has no genuine coverage for those governance and quality threats; mapping them would assert coverage that does not exist.

`target-reference.entry-type` is `Control` rather than `Vector`, matching `threats-ccm-v4.yaml`. ATLAS, CWE and the OWASP LLM Top 10 are attack taxonomies; ATR rules are detections.

The mapping is one-way and lossy — an ATR rule id indicates detection coverage adjacent to a threat, not an equivalence. Same caveat as the metadata note in #986.

## Verification

Re-run today against current `main` rather than relying on the earlier green, with the toolchain this repo pins (`cue v0.16.0`, `gemara v1.2.0`):

```
delivery-toolkit compile --build-target ai-ml/gen-ai --type threats   → ok
cue vet -d '#ThreatCatalog'  github.com/gemaraproj/gemara@v1.2.0 …    → ok
delivery-toolkit compile --build-target ai-ml/gen-ai --type mappings  → 5 documents
cue vet -d '#MappingDocument' github.com/gemaraproj/gemara@v1.2.0 …   → all 5 pass
```

Every ATR rule id referenced was re-checked against the current published ruleset (3.5.11): all 24 exist, none is deprecated. They were last verified when this PR was opened, and rules do get deprecated, so the check was repeated rather than assumed.

## One thing worth flagging separately

The `Compile and validate touched catalog YAMLs` job loops over `capabilities threats controls` only. `delivery-toolkit` already supports `--type mappings`, but CI never invokes it, so no mapping document under `catalogs/*/*/mappings/` is schema-validated — including the four that #1129 merged.

Nothing is currently wrong: I ran the missing step against all five documents in this catalog and they all pass. It is a latent gap rather than a live failure, and adding `mappings` to that asset loop would close it. Happy to send that as its own PR if it is wanted; it is out of scope here.
