### PR TITLE
feat: Added a button for downloading raw yaml files from catalog pages

### DIFF
--- a/website/src/components/Catalogs/CatalogTypePage.tsx
+++ b/website/src/components/Catalogs/CatalogTypePage.tsx
@@ -37,6 +37,23 @@ export const CatalogTypePage: React.FC<Props> = ({ data }) => {
   const typeLabel = TYPE_LABELS[type] ?? type.charAt(0).toUpperCase() + type.slice(1);
   const activeData = allVersionData[selectedIdx];
 
+  const yamlName = `${data.category}/${data.service}/${data.type}.yaml`;
+  const yamlLink = `https://raw.githubusercontent.com/finos/common-cloud-controls/refs/heads/main/catalogs/${yamlName}`;
+
+  async function downloadFromGithub(rawUrl: string, filename?: string) {
+      const resp = await fetch(rawUrl, { headers: { Accept: 'application/octet-stream' } });
+      if (!resp.ok) throw new Error(`Download failed: ${resp.status}`);
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename ?? (rawUrl.split('/').pop() ?? 'file');
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+  }
+
   return (
     <div className="page-layout">
       <CatalogSidebar />
@@ -64,6 +81,11 @@ export const CatalogTypePage: React.FC<Props> = ({ data }) => {
                   {vPath.split("/").pop()}{i === 0 ? " (latest)" : ""}
                 </button>
               ))}
+
+              <button className="catalog-type-btn" style={{marginLeft:"auto", fontSize: "0.85rem"}} onClick={() => downloadFromGithub(
+                yamlLink,
+                yamlName
+              )}>Download file from GitHub</button>
             </div>
             {activeData && <CatalogTable data={activeData} />}
           </>

--- a/website/src/components/Catalogs/CatalogVersionPage.tsx
+++ b/website/src/components/Catalogs/CatalogVersionPage.tsx
@@ -95,7 +95,26 @@ export const CatalogTable: React.FC<{ data: CatalogVersionData }> = ({ data }) =
   const showThreatColumns = data.type === "threats";
   const showControlColumns = data.type === "controls";
   const sortedEntries = [...data.entries].sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
-  const typePath = `/catalogs/${data.category}/${data.service}/${data.type}/${data.version}`;
+
+  const typePath = `${data.category}/${data.service}/${data.type}`;
+  const versionPath = `/catalogs/${typePath}/${data.version}`;
+  const yamlName = `${typePath}.yaml`;
+  const yamlLink = `https://raw.githubusercontent.com/finos/common-cloud-controls/refs/heads/main/catalogs/${yamlName}`;
+
+  async function downloadFromGithub(rawUrl: string, filename?: string) {
+    const resp = await fetch(rawUrl, { headers: { Accept: 'application/octet-stream' } });
+    if (!resp.ok) throw new Error(`Download failed: ${resp.status}`);
+    const blob = await resp.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename ?? (rawUrl.split('/').pop() ?? 'file');
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <div className="library-article-body">
       {sortedEntries.length > 0  &&(
@@ -127,7 +146,7 @@ export const CatalogTable: React.FC<{ data: CatalogVersionData }> = ({ data }) =
           {sortedEntries.map((entry) => (
             <tr key={entry.id}>
               <td>
-                <Link to={`${typePath}/${entry.id}`}>{entry.id}</Link>
+                <Link to={`${versionPath}/${entry.id}`}>{entry.id}</Link>
               </td>
               <td>{entry.title}</td>
               <td>{data.type === "controls" ? entry.objective : entry.description}</td>
@@ -189,6 +208,11 @@ export const CatalogTable: React.FC<{ data: CatalogVersionData }> = ({ data }) =
         </tbody>
       </table>
       </div>)}
+
+      <button onClick={() => downloadFromGithub(
+        yamlLink,
+        yamlName
+      )}>Download file from GitHub</button>
     </div>
   );
 };

--- a/website/src/components/Catalogs/CatalogVersionPage.tsx
+++ b/website/src/components/Catalogs/CatalogVersionPage.tsx
@@ -95,26 +95,7 @@ export const CatalogTable: React.FC<{ data: CatalogVersionData }> = ({ data }) =
   const showThreatColumns = data.type === "threats";
   const showControlColumns = data.type === "controls";
   const sortedEntries = [...data.entries].sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
-
-  const typePath = `${data.category}/${data.service}/${data.type}`;
-  const versionPath = `/catalogs/${typePath}/${data.version}`;
-  const yamlName = `${typePath}.yaml`;
-  const yamlLink = `https://raw.githubusercontent.com/finos/common-cloud-controls/refs/heads/main/catalogs/${yamlName}`;
-
-  async function downloadFromGithub(rawUrl: string, filename?: string) {
-    const resp = await fetch(rawUrl, { headers: { Accept: 'application/octet-stream' } });
-    if (!resp.ok) throw new Error(`Download failed: ${resp.status}`);
-    const blob = await resp.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename ?? (rawUrl.split('/').pop() ?? 'file');
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  }
-
+  const typePath = `/catalogs/${data.category}/${data.service}/${data.type}/${data.version}`;
   return (
     <div className="library-article-body">
       {sortedEntries.length > 0  &&(
@@ -146,7 +127,7 @@ export const CatalogTable: React.FC<{ data: CatalogVersionData }> = ({ data }) =
           {sortedEntries.map((entry) => (
             <tr key={entry.id}>
               <td>
-                <Link to={`${versionPath}/${entry.id}`}>{entry.id}</Link>
+                <Link to={`${typePath}/${entry.id}`}>{entry.id}</Link>
               </td>
               <td>{entry.title}</td>
               <td>{data.type === "controls" ? entry.objective : entry.description}</td>
@@ -208,11 +189,6 @@ export const CatalogTable: React.FC<{ data: CatalogVersionData }> = ({ data }) =
         </tbody>
       </table>
       </div>)}
-
-      <button className="catalog-type-btn" onClick={() => downloadFromGithub(
-        yamlLink,
-        yamlName
-      )}>Download file from GitHub</button>
     </div>
   );
 };

--- a/website/src/components/Catalogs/CatalogVersionPage.tsx
+++ b/website/src/components/Catalogs/CatalogVersionPage.tsx
@@ -209,7 +209,7 @@ export const CatalogTable: React.FC<{ data: CatalogVersionData }> = ({ data }) =
       </table>
       </div>)}
 
-      <button onClick={() => downloadFromGithub(
+      <button className="catalog-type-btn" onClick={() => downloadFromGithub(
         yamlLink,
         yamlName
       )}>Download file from GitHub</button>


### PR DESCRIPTION
## Summary
-Added a download button to the catalog pages that directly downloads the associated raw yaml file

## Related issues
#1172 

## Checklist

- [ ] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [ ] Tests / docs updated as needed
