### PR TITLE
docs: update taxonomy working meeting cadence

### DIFF
--- a/.github/ISSUE_TEMPLATE/minutes_taxonomy.md
+++ b/.github/ISSUE_TEMPLATE/minutes_taxonomy.md
@@ -10,7 +10,7 @@ assignees: "smendis-scottlogic"
 
 ## Date
 
-MM/DD/YYYY - 11:30 ET / 16:30 UK
+MM/DD/YYYY - HH:mm ET / HH:mm UK
 
 - [Join Zoom Meeting](https://zoom.us/j/994109603410)
 - Meeting ID: 941 0960 3410

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The CCC project is currently split into 6 working groups as follows:
 - **Taxonomy** - Focused on defining the taxonomy of cloud services that will be covered by the standard.
 - **Compliant Financial Infrastructure** - Focused on delivery of actual implementations of cloud infrastructure meeting CCC standards.
 
-Work is done in the open, with all meetings and decisions documented in the project GitHub repository. Working groups meet on a fortnightly basis:
+Work is done in the open, with all meetings and decisions documented in the project GitHub repository. Working groups meet regularly; cadence varies by group — see the table below and the FINOS Community Calendar:
 
 | Working Group                                                                           | When                                                    | Chair               | Mailing List                                                              |
 | --------------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------- |

--- a/docs/governance/working-groups/taxonomy/charter.md
+++ b/docs/governance/working-groups/taxonomy/charter.md
@@ -62,7 +62,6 @@ The membership structure of this working group.
 ### Meeting & Communication
 
 - This working group will use the mail group <ccc-taxonomy@lists.finos.org> for regular communications.
-- This group will host an informal recurring WG meeting every two weeks, with possible interferences on global holidays.
 - The WG Lead or their delegate must present verbal or written updates to the [SC] at its regular public meetings.
 
 ### Changes


### PR DESCRIPTION
## Summary

Taxonomy working group meeting cadence changed from biweekly to adhoc.

## Related issues

<!-- Replace this comment with issue references, e.g. `Closes #123`. Delete the section if none apply. -->

## Checklist

- [ ] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [ ] Tests / docs updated as needed
