### PR TITLE
feat: added import count to the total counts (second pr)

### DIFF
--- a/website/src/plugin/catalog-routes/index.ts
+++ b/website/src/plugin/catalog-routes/index.ts
@@ -589,7 +589,7 @@ export default function pluginCatalogRoutes(context: LoadContext): Plugin<Plugin
           });
         }
         const summary = verMap.get(data.version)!;
-        summary[`${data.type}Count` as 'capabilitiesCount' | 'threatsCount' | 'controlsCount'] = data.entries.length;
+        summary[`${data.type}Count` as 'capabilitiesCount' | 'threatsCount' | 'controlsCount'] = data.entries.length + data.imports.length;
         summary.typePaths[data.type] = urlPath;
       }
 


### PR DESCRIPTION
## Summary
-The tables displaying the counts of capabilities/threats/controls for each catalog now totals the entries *and* imports for each service (second attempt due to white-space issue in #1185)

## Related issues
#1183 

## Checklist

- [ ] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [ ] Tests / docs updated as needed
