### PR TITLE
feat: Changed color of links when in dark mode

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -16,7 +16,6 @@
   --ifm-navbar-link-color: #0086bf;
   --ifm-footer-background-color: #effbff;
 
-
   --gf-color-text: #0086bf;
   --gf-color-text-subtle: #94a3b8;
 
@@ -41,6 +40,7 @@
   --ifm-color-primary-lighter: #ffffff;
   --ifm-color-primary-lightest: #ffffff;
   --ifm-footer-background-color: rgba(15, 21, 62, 0.65);;
+  --ifm-link-color: #3b82f6;
 
 
   --gf-color-text: #e2e8f0;


### PR DESCRIPTION
## Summary
Links in dark mode are now a light blue to better contrast with body text

<!-- Replace this comment with a description of what this PR changes, and why. -->

## Related issues
#1204 
<!-- Replace this comment with issue references, e.g. `Closes #123`. Delete the section if none apply. -->

## Checklist

- [ ] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [ ] Tests / docs updated as needed
