### PR TITLE
fix: correct MITRE ATT&CK mapping content carried over from inline data

### DIFF
--- a/catalogs/core/core/mappings/threats-mitre-attack.yaml
+++ b/catalogs/core/core/mappings/threats-mitre-attack.yaml
@@ -199,16 +199,8 @@ mappings:
     remarks: Data Manipulation
   - entry-id: T1489
     remarks: Service Stop
-  - entry-id: T1562.01
+  - entry-id: T1562.010
     remarks: 'Impair Defenses: Downgrade Attack'
-  - entry-id: T1027
-    remarks: Obfuscated Files or Information
-  - entry-id: T1485
-    remarks: Data Destruction
-  - entry-id: T1565
-    remarks: Data Manipulation
-  - entry-id: T1489
-    remarks: Service Stop
 - id: CCC.Core.TH15-mitre-attack
   source: CCC.Core.TH15
   relationship: relates-to

--- a/catalogs/management/auditlog/mappings/threats-mitre-attack.yaml
+++ b/catalogs/management/auditlog/mappings/threats-mitre-attack.yaml
@@ -29,12 +29,14 @@ mappings:
   source: CCC.AUDITLOG.TH02
   relationship: relates-to
   targets:
-  - entry-id: TA0005
+  - entry-id: T1562.008
+    remarks: 'Impair Defenses: Disable or Modify Cloud Logs'
 - id: CCC.AUDITLOG.TH03-mitre-attack
   source: CCC.AUDITLOG.TH03
   relationship: relates-to
   targets:
-  - entry-id: TA0006
+  - entry-id: T1552
+    remarks: Unsecured Credentials
 remarks: Migrated from inline external-mappings previously on threats.yaml. relationship is a conservative
   'relates-to' default (the source carried no relationship semantics); framework version and the target
   entry-type for non-attack frameworks (OWASP, CWE) are provisional, pending WG review.


### PR DESCRIPTION
## Summary :robot:

- Core TH14: remove duplicated targets (T1027, T1485, T1565, T1489 were listed twice) and fix malformed sub-technique ID T1562.01 -> T1562.010 (Impair Defenses: Downgrade Attack, matching the remark).
- AuditLog TH02/TH03: replace ATT&CK tactic IDs (TA0005, TA0006) with technique-level entries (T1562.008, T1552) to match the document's Vector target entry-type.

## Related issues

None

## Checklist

- [x] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [x] Tests / docs updated as needed
