### PR TITLE
fix: resolve stale core imports left over from identifier change

### DIFF
--- a/catalogs/app-integration/message/capabilities.yaml
+++ b/catalogs/app-integration/message/capabilities.yaml
@@ -23,13 +23,13 @@ imports:
         remarks: Child Resource Scaling
       - reference-id: CCC.Core.CP20
         remarks: Resource Tagging
-      - reference-id: CCC.Core.F23
+      - reference-id: CCC.Core.CP23
         remarks: Network Access Rules
-      - reference-id: CCC.Core.F28
+      - reference-id: CCC.Core.CP28
         remarks: Command-line Interface
-      - reference-id: CCC.Core.F29
+      - reference-id: CCC.Core.CP29
         remarks: Active Ingestion
-      - reference-id: CCC.Core.F31
+      - reference-id: CCC.Core.CP31
         remarks: Elastic Scaling
 
 capabilities:

--- a/catalogs/compute/batchproc/capabilities.yaml
+++ b/catalogs/compute/batchproc/capabilities.yaml
@@ -19,19 +19,19 @@ imports:
         remarks: API Access
       - reference-id: CCC.Core.CP19
         remarks: Child Resource Scaling
-      - reference-id: CCC.Core.F23
+      - reference-id: CCC.Core.CP23
         remarks: Network Access Rules
-      - reference-id: CCC.Core.F24
+      - reference-id: CCC.Core.CP24
         remarks: Core Processing Units
-      - reference-id: CCC.Core.F25
+      - reference-id: CCC.Core.CP25
         remarks: Random Access Memory Allocation
-      - reference-id: CCC.Core.F26
+      - reference-id: CCC.Core.CP26
         remarks: Persistent Storage
-      - reference-id: CCC.Core.F28
+      - reference-id: CCC.Core.CP28
         remarks: Command-line Interface
-      - reference-id: CCC.Core.F29
+      - reference-id: CCC.Core.CP29
         remarks: Active Ingestion
-      - reference-id: CCC.Core.F31
+      - reference-id: CCC.Core.CP31
         remarks: Elastic Scaling
 
 capabilities:

--- a/catalogs/compute/virtual-machines/capabilities.yaml
+++ b/catalogs/compute/virtual-machines/capabilities.yaml
@@ -25,17 +25,17 @@ imports:
         remarks: Location Lock-In
       - reference-id: CCC.Core.CP23
         remarks: Network Access Rules
-      - reference-id: CCC.Core.F24
+      - reference-id: CCC.Core.CP24
         remarks: Core Processing Units
-      - reference-id: CCC.Core.F25
+      - reference-id: CCC.Core.CP25
         remarks: Random Access Memory Allocation
-      - reference-id: CCC.Core.F26
+      - reference-id: CCC.Core.CP26
         remarks: Persistent Storage
-      - reference-id: CCC.Core.F27
+      - reference-id: CCC.Core.CP27
         remarks: Configurable Network Ports
-      - reference-id: CCC.Core.F28
+      - reference-id: CCC.Core.CP28
         remarks: Command-line Interface
-      - reference-id: CCC.Core.F29
+      - reference-id: CCC.Core.CP29
         remarks: Active Ingestion
 
 capabilities:

--- a/catalogs/compute/virtual-machines/controls.yaml
+++ b/catalogs/compute/virtual-machines/controls.yaml
@@ -17,5 +17,3 @@ imports:
         strength: 0 # Not yet specified
       - reference-id: CCC.Core.CN11
         strength: 0 # Not yet specified
-      - reference-id: CCC.Core.CN12
-        strength: 0 # Not yet specified

--- a/catalogs/crypto/key/capabilities.yaml
+++ b/catalogs/crypto/key/capabilities.yaml
@@ -19,11 +19,11 @@ imports:
         remarks: Log Publication
       - reference-id: CCC.Core.CP14
         remarks: API Access
-      - reference-id: CCC.Core.F19
-        remarks: Resource Scaling
-      - reference-id: CCC.Core.F28
+      - reference-id: CCC.Core.CP31
+        remarks: Elastic Scaling
+      - reference-id: CCC.Core.CP28
         remarks: Command-line
-      - reference-id: CCC.Core.F29
+      - reference-id: CCC.Core.CP29
         remarks: Active Ingestion
 capabilities:
   - id: CCC.KeyMgmt.CP01

--- a/catalogs/database/relational/controls.yaml
+++ b/catalogs/database/relational/controls.yaml
@@ -31,9 +31,6 @@ imports:
       - reference-id: CCC.Core.CN10
         strength: 0 # Not yet specified
         remarks: Prevent data replication to destinations outside of defined trust perimeter
-      - reference-id: CCC.Core.CN12
-        strength: 0 # Not yet specified
-        remarks: Ensure Secure Network Access Rules
 
 controls:
   - id: CCC.RDMS.CN01

--- a/catalogs/database/vector/controls.yaml
+++ b/catalogs/database/vector/controls.yaml
@@ -28,9 +28,6 @@ imports:
       - reference-id: CCC.Core.CN10
         strength: 0 # Not yet specified
         remarks: Prevent Replication Outside Trust Boundary
-      - reference-id: CCC.Core.CN12
-        strength: 0 # Not yet specified
-        remarks: Secure Network Access Rules
 
 controls:
   - id: CCC.Vector.CN01

--- a/catalogs/devtools/build/capabilities.yaml
+++ b/catalogs/devtools/build/capabilities.yaml
@@ -17,13 +17,13 @@ imports:
         remarks: Log Publication
       - reference-id: CCC.Core.CP14
         remarks: API Access
-      - reference-id: CCC.Core.F23
+      - reference-id: CCC.Core.CP23
         remarks: Network Access Rules
-      - reference-id: CCC.Core.F26
+      - reference-id: CCC.Core.CP26
         remarks: Persistent Storage
-      - reference-id: CCC.Core.F28
+      - reference-id: CCC.Core.CP28
         remarks: Command-line Interface
-      - reference-id: CCC.Core.F29
+      - reference-id: CCC.Core.CP29
         remarks: Active Ingestion
 
 capabilities:


### PR DESCRIPTION
## Summary 🤖 

- Rename CCC.Core.F23-F29/F31 imports to their CP-series equivalents in message, batchproc, virtual-machines, crypto/key, and devtools/build (each ref's remark title-matches the renamed core capability).
- crypto/key: F19 (Resource Scaling) becomes CP31 (Elastic Scaling), following how #949 split the old capability for managed services.
- Drop CCC.Core.CN12 imports from relational, vector, and virtual-machines controls: old C12 (Secure Network Access Rules) was removed from the core catalog before the CN rename and has no current equivalent; all three catalogs already import CN05.

## Related issues

None

## Checklist

- [x] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [x] Tests / docs updated as needed
