### PR TITLE
fix: resolve references to nonexistent load balancer threats

### DIFF
--- a/catalogs/networking/loadbalancer/controls.yaml
+++ b/catalogs/networking/loadbalancer/controls.yaml
@@ -61,9 +61,6 @@ controls:
           - reference-id: CCC.LB.TH01
             strength: 0 # Not yet specified
             remarks: Malicious Traffic
-          - reference-id: CCC.LB.TH09
-            strength: 0 # Not yet specified
-            remarks: Resource Exhaustion
     guidelines:
       - reference-id: NIST-CSF
         entries:
@@ -217,9 +214,9 @@ controls:
     threats:
       - reference-id: LB
         entries:
-          - reference-id: CCC.LB.TH08
+          - reference-id: CCC.Core.TH01
             strength: 0 # Not yet specified
-            remarks: API Exposed and Attacked
+            remarks: Access Control is Misconfigured
     guidelines:
       - reference-id: NIST-CSF
         entries:
@@ -252,9 +249,9 @@ controls:
     threats:
       - reference-id: LB
         entries:
-          - reference-id: CCC.LB.TH09
+          - reference-id: CCC.LB.TH01
             strength: 0 # Not yet specified
-            remarks: Resource Exhaustion
+            remarks: Unrestricted Request Traffic Overwhelms Downstream Services
     guidelines:
       - reference-id: NIST-CSF
         entries:


### PR DESCRIPTION
## Summary 🤖 

CCC.LB.TH08 and TH09 were referenced by controls but never existed in any version of the threat catalog (the controls were written against a draft numbering that never landed).

- CN01: drop the TH09 (Resource Exhaustion) ref; the control already references TH01, which covers unrestricted traffic overwhelming downstream services.
- CN02: remap TH09 to TH01 for the same reason.
- CN09: remap TH08 (API Exposed and Attacked) to CCC.Core.TH01 (Access Control is Misconfigured), the closest existing threat, following the file's existing pattern of core threat refs (see CN07).

## Related issues

None

## Checklist

- [x] PR title follows the Conventional Commits format (see the guide at the top of this template)
- [x] Tests / docs updated as needed
